### PR TITLE
Solve #6 - Add a GitHub fetcher component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,11 @@ gem "rake", "~> 13.0"
 
 gem "net-imap", "~> 0.4.10"
 gem "net-smtp", "~> 0.4.0.1"
+
+gem 'octokit', '~> 8.1.0'
+gem 'jwt', '~> 2.8.1'
+gem 'openssl', '~> 3.2'
+
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.21"
 gem "simplecov", require: false, group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -5,14 +5,15 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in bas.gemspec
 gemspec
 
+gem "jwt", "~> 2.8.1"
+
 gem "rake", "~> 13.0"
 
 gem "net-imap", "~> 0.4.10"
 gem "net-smtp", "~> 0.4.0.1"
 
-gem 'octokit', '~> 8.1.0'
-gem 'jwt', '~> 2.8.1'
-gem 'openssl', '~> 3.2'
+gem "octokit", "~> 8.1.0"
+gem "openssl", "~> 3.2"
 
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.21"

--- a/lib/bas/domain/issue.rb
+++ b/lib/bas/domain/issue.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Domain
+  ##
+  # The Domain::Issue class provides a domain-specific representation of a Github issue object.
+  # It encapsulates information about a repository issue, including the title, state, assignees,
+  # description, and the repository url.
+  #
+  class Issue
+    attr_reader :title, :state, :assignees, :description, :url
+
+    ATTRIBUTES = %w[title state assignees description url].freeze
+
+    def initialize(title, state, assignees, body, url)
+      @title = title
+      @state = state
+      @assignees = assignees
+      @description = body
+      @url = url
+    end
+  end
+end

--- a/lib/bas/fetcher/github/base.rb
+++ b/lib/bas/fetcher/github/base.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
-require 'octokit'
-require 'openssl'
-require 'jwt'
+require "octokit"
+require "openssl"
+require "jwt"
 
 require_relative "../base"
 require_relative "./types/response"
-# require_relative "./helper"
 
 module Fetcher
   module Github

--- a/lib/bas/fetcher/github/base.rb
+++ b/lib/bas/fetcher/github/base.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'octokit'
+require 'openssl'
+require 'jwt'
+
+require_relative "../base"
+require_relative "./types/response"
+# require_relative "./helper"
+
+module Fetcher
+  module Github
+    ##
+    # This class is an implementation of the Fetcher::Base interface, specifically designed
+    # for fetching data from a GitHub repository.
+    #
+    class Base < Fetcher::Base
+      protected
+
+      # Implements the data fetching logic to get data from a Github repository.
+      # It connects to Github using the octokit gem, authenticates with a github app,
+      # request the data and returns a validated response.
+      #
+      def execute(method, *filter)
+        octokit_response = octokit.public_send(method, *filter)
+
+        Fetcher::Github::Types::Response.new(octokit_response)
+      end
+
+      private
+
+      def octokit
+        Octokit::Client.new(bearer_token: access_token)
+      end
+
+      def access_token
+        app = Octokit::Client.new(client_id: config[:app_id], bearer_token: jwt)
+
+        app.create_app_installation_access_token(config[:installation_id])[:token]
+      end
+
+      def jwt
+        private_pem = File.read(config[:secret_path])
+        private_key = OpenSSL::PKey::RSA.new(private_pem)
+
+        JWT.encode(jwt_payload, private_key, "RS256")
+      end
+
+      def jwt_payload
+        {
+          iat: Time.now.to_i - 60,
+          exp: Time.now.to_i + (10 * 60),
+          iss: config[:app_id]
+        }
+      end
+    end
+  end
+end

--- a/lib/bas/fetcher/github/types/response.rb
+++ b/lib/bas/fetcher/github/types/response.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Fetcher
+  module Github
+    module Types
+      ##
+      # Represents a response received from the Octokit Github client. It encapsulates essential
+      # information about the response, providing a structured way to handle and analyze
+      # it's responses.
+      class Response
+        attr_reader :status_code, :message, :results
+
+        def initialize(response)
+          if response.empty?
+            @status_code = 404
+            @message = "no result were found"
+            @results = []
+          else
+            @status_code = 200
+            @message = "success"
+            @results = response
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bas/fetcher/github/use_case/repo_issues.rb
+++ b/lib/bas/fetcher/github/use_case/repo_issues.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "../base"
+
+module Fetcher
+  module Github
+    ##
+    # This class is an implementation of the Fetcher::Github::Base interface, specifically designed
+    # for fetching issues from a Github repository.
+    #
+    class RepoIssues < Github::Base
+
+      def fetch
+        execute("list_issues", config[:repo])
+      end
+    end
+  end
+end

--- a/lib/bas/fetcher/github/use_case/repo_issues.rb
+++ b/lib/bas/fetcher/github/use_case/repo_issues.rb
@@ -9,7 +9,6 @@ module Fetcher
     # for fetching issues from a Github repository.
     #
     class RepoIssues < Github::Base
-
       def fetch
         execute("list_issues", config[:repo])
       end

--- a/lib/bas/use_cases/use_cases.rb
+++ b/lib/bas/use_cases/use_cases.rb
@@ -8,6 +8,7 @@ require_relative "../fetcher/notion/use_case/pto_next_week"
 require_relative "../fetcher/notion/use_case/work_items_limit"
 require_relative "../fetcher/postgres/use_case/pto_today"
 require_relative "../fetcher/imap/use_case/support_emails"
+require_relative "../fetcher/github/use_case/repo_issues"
 
 # mapper
 require_relative "../mapper/notion/birthday_today"
@@ -15,6 +16,7 @@ require_relative "../mapper/notion/pto_today"
 require_relative "../mapper/notion/work_items_limit"
 require_relative "../mapper/postgres/pto_today"
 require_relative "../mapper/imap/support_emails"
+require_relative "../mapper/github/issues"
 
 # formatter
 require_relative "../formatter/birthday"

--- a/spec/bas/fetcher/github/repo_issues_spec.rb
+++ b/spec/bas/fetcher/github/repo_issues_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe Fetcher::Github::RepoIssues do
+  before do
+    config = {
+      app_id: "123456",
+      installation_id: "78910",
+      secret_path: "secrets_file_path.pem",
+      repo: "Organization/Repository"
+    }
+
+    @fetcher = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@fetcher).to respond_to(:config) }
+    it { expect(@fetcher).to respond_to(:fetch).with(0).arguments }
+  end
+
+  describe ".fetch" do
+    let(:empty_response) { [] }
+    let(:response) { [{ url: "repo_url" }] }
+
+    let(:octokit) do
+      stub = {
+        create_app_installation_access_token: { token: "access_token" }
+      }
+
+      instance_double(Octokit::Client, stub)
+    end
+
+    before do
+      allow(File).to receive(:read).and_return("private_pem")
+      allow(OpenSSL::PKey::RSA).to receive(:new).and_return("private_key")
+      allow(JWT).to receive(:encode).and_return("jwt_token")
+      allow(Octokit::Client).to receive(:new).and_return(octokit)
+    end
+
+    it "fetch emails from the Github repo when there are not 'issues'" do
+      allow(octokit).to receive(:public_send).and_return(empty_response)
+
+      fetched_data = @fetcher.fetch
+
+      expect(fetched_data).to be_an_instance_of(Fetcher::Github::Types::Response)
+      expect(fetched_data.results).to be_an_instance_of(Array)
+      expect(fetched_data.results.length).to eq(0)
+    end
+
+    it "fetch emails from the Github repo when there are 'issues'" do
+      allow(octokit).to receive(:public_send).and_return(response)
+
+      fetched_data = @fetcher.fetch
+
+      expect(fetched_data).to be_an_instance_of(Fetcher::Github::Types::Response)
+      expect(fetched_data.results).to be_an_instance_of(Array)
+      expect(fetched_data.results.length).to eq(1)
+    end
+  end
+end

--- a/spec/bas/fetcher/github/repo_issues_spec.rb
+++ b/spec/bas/fetcher/github/repo_issues_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Fetcher::Github::RepoIssues do
       allow(Octokit::Client).to receive(:new).and_return(octokit)
     end
 
-    it "fetch emails from the Github repo when there are not 'issues'" do
+    it "fetch issues from the Github repo when there are no 'issues'" do
       allow(octokit).to receive(:public_send).and_return(empty_response)
 
       fetched_data = @fetcher.fetch
@@ -48,7 +48,7 @@ RSpec.describe Fetcher::Github::RepoIssues do
       expect(fetched_data.results.length).to eq(0)
     end
 
-    it "fetch emails from the Github repo when there are 'issues'" do
+    it "fetch issues from the Github repo when there are 'issues'" do
       allow(octokit).to receive(:public_send).and_return(response)
 
       fetched_data = @fetcher.fetch

--- a/spec/bas/mapper/github/issues_spec.rb
+++ b/spec/bas/mapper/github/issues_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Mapper::Github::Issues do
-  let(:assignees) { [{ :login => "username" }] }
-  let(:issues) {
+  let(:assignees) { [{ login: "username" }] }
+  let(:issues) do
     [{
       url: "repo_url",
       title: "title",
@@ -10,7 +10,7 @@ RSpec.describe Mapper::Github::Issues do
       assignees: assignees,
       description: "description"
     }]
-  }
+  end
 
   before do
     @imap_response = Fetcher::Github::Types::Response.new(issues)

--- a/spec/bas/mapper/github/issues_spec.rb
+++ b/spec/bas/mapper/github/issues_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Mapper::Github::Issues do
+  let(:assignees) { [{ :login => "username" }] }
+  let(:issues) {
+    [{
+      url: "repo_url",
+      title: "title",
+      state: "state",
+      assignees: assignees,
+      description: "description"
+    }]
+  }
+
+  before do
+    @imap_response = Fetcher::Github::Types::Response.new(issues)
+    @mapper = described_class.new
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(0).arguments }
+    it { expect(@mapper).to respond_to(:map).with(1).arguments }
+  end
+
+  describe ".map" do
+    it "maps the given data into an array of Domain::Issue instances" do
+      mapped_data = @mapper.map(@imap_response)
+
+      are_issues = mapped_data.all? { |element| element.is_a?(Domain::Issue) }
+
+      expect(mapped_data).to be_an_instance_of(Array)
+      expect(mapped_data.length).to eq(1)
+      expect(are_issues).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Closes #6

## Description

In this PR the GitHub issues fetcher and mapper were added. The fetching is applied using the [octokit](https://rubygems.org/gems/octokit/versions/4.3.0?locale=en) gem. The authentication is applied with a [GitHub app](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app) created for the account or organization and then installed into the repo. Fetcher config:
```ruby
# fetcher options
fetch_options: {
  app_id: APP_ID,
  installation_id: INSTALLATION_ID,
  secret_path: PATH_TO_SECRETS,
  repo: REPO_NAME
}
```