### PR TITLE
Solve #11 - Update PTO use cases columns names

### DIFF
--- a/lib/bas/fetcher/imap/use_case/support_emails.rb
+++ b/lib/bas/fetcher/imap/use_case/support_emails.rb
@@ -16,7 +16,7 @@ module Fetcher
       # Implements the data fetching filter for support emails from Google Gmail.
       #
       def fetch
-        yesterday = (Time.now - (60 * 60 * 24)).strftime("%e-%b-%Y")
+        yesterday = (Time.now - (60 * 60 * 24)).strftime("%d-%b-%Y")
         query = ["TO", config[:search_email], "SINCE", yesterday]
 
         execute(EMAIL_DOMAIN, EMAIL_PORT, TOKEN_URI, query)

--- a/lib/bas/mapper/notion/pto_today.rb
+++ b/lib/bas/mapper/notion/pto_today.rb
@@ -12,7 +12,7 @@ module Mapper
     class PtoToday
       include Base
 
-      PTO_PARAMS = ["Person", "Desde?", "Hasta?"].freeze
+      PTO_PARAMS = ["Description", "Desde?", "Hasta?"].freeze
 
       # Implements the logic for shaping the results from a fetcher response.
       #
@@ -30,7 +30,7 @@ module Mapper
         normalized_notion_data = normalize_response(notion_response.results)
 
         normalized_notion_data.map do |pto|
-          Domain::Pto.new(pto["Person"], pto["Desde?"], pto["Hasta?"])
+          Domain::Pto.new(pto["Description"], pto["Desde?"], pto["Hasta?"])
         end
       end
 
@@ -43,15 +43,17 @@ module Mapper
           pto_fields = value["properties"].slice(*PTO_PARAMS)
 
           {
-            "Person" => extract_person_field_value(pto_fields["Person"]),
+            "Description" => extract_description_field_value(pto_fields["Description"]),
             "Desde?" => extract_date_field_value(pto_fields["Desde?"]),
             "Hasta?" => extract_date_field_value(pto_fields["Hasta?"])
           }
         end
       end
 
-      def extract_person_field_value(data)
-        data["people"][0]["name"]
+      def extract_description_field_value(data)
+        names = data["title"].map { |name| name["plain_text"] }
+
+        names.join(" ")
       end
 
       def extract_date_field_value(date)

--- a/spec/bas/mapper/notion/pto_spec.rb
+++ b/spec/bas/mapper/notion/pto_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Mapper::Notion::PtoToday do
     @mapper = described_class.new
     fetcher_config = {
       base_url: "https://api.notion.com",
-      database_id: "b68d11061aad43bd89f8f525ede2b598",
-      secret: "secret_ZELfDH6cf4Glc9NLPLxvsvdl9iZVD4qBCyMDXqch51C",
+      database_id: "8187370982134ed099f9d14385aa81c9",
+      secret: "secret_K5UCqm27GvAscTlaGJmS2se4fyM1K7is3OIZMw03NaC",
       filter: {
         "filter": {
           "and": [

--- a/spec/fixtures/vcr_cassettes/notion/ptos/fetch_with_filter.yml
+++ b/spec/fixtures/vcr_cassettes/notion/ptos/fetch_with_filter.yml
@@ -55,4 +55,60 @@ http_interactions:
       string: !binary |-
         eyJvYmplY3QiOiJsaXN0IiwicmVzdWx0cyI6W3sib2JqZWN0IjoicGFnZSIsImlkIjoiMWNlYTMyYjgtNDM4Ni00M2ExLWFmZWEtNmZkZGZhZGZmNDVmIiwiY3JlYXRlZF90aW1lIjoiMjAyNC0wMS0yM1QxODo0NzowMC4wMDBaIiwibGFzdF9lZGl0ZWRfdGltZSI6IjIwMjQtMDEtMjRUMDM6Mjg6MDAuMDAwWiIsImNyZWF0ZWRfYnkiOnsib2JqZWN0IjoidXNlciIsImlkIjoiYzZiOGExZDctYWQyMS00YmFkLTkyYTktNmM1MzEwZWM4MjVhIn0sImxhc3RfZWRpdGVkX2J5Ijp7Im9iamVjdCI6InVzZXIiLCJpZCI6ImM2YjhhMWQ3LWFkMjEtNGJhZC05MmE5LTZjNTMxMGVjODI1YSJ9LCJjb3ZlciI6bnVsbCwiaWNvbiI6bnVsbCwicGFyZW50Ijp7InR5cGUiOiJkYXRhYmFzZV9pZCIsImRhdGFiYXNlX2lkIjoiYjY4ZDExMDYtMWFhZC00M2JkLTg5ZjgtZjUyNWVkZTJiNTY3In0sImFyY2hpdmVkIjpmYWxzZSwicHJvcGVydGllcyI6eyJQZXJzb24iOnsiaWQiOiIlM0QlM0RhJTQwIiwidHlwZSI6InBlb3BsZSIsInBlb3BsZSI6W3sib2JqZWN0IjoidXNlciIsImlkIjoiYzM5Y2YyYTYtNzdmMy00NTBmLTgzN2EtNzdjYTJjNzY2YWI4IiwibmFtZSI6IkxvcmVuem8gWnVsdWFnYSIsImF2YXRhcl91cmwiOiJodHRwczovL3MzLXVzLXdlc3QtMi5hbWF6b25hd3MuY29tL3B1YmxpYy5ub3Rpb24tc3RhdGljLmNvbS8wN2QwNTAzNC1hMTU3LTRlOTEtOTc3OC0xMGE3NGViYmZhNGYvcGhvdG9fMjAyMC0wMi0xMF8wOS01Mi0zOS5qcGciLCJ0eXBlIjoicGVyc29uIiwicGVyc29uIjp7fX1dfSwiQ3JlYXRlZCI6eyJpZCI6IiUzRCU1RE1wIiwidHlwZSI6ImNyZWF0ZWRfdGltZSIsImNyZWF0ZWRfdGltZSI6IjIwMjQtMDEtMjNUMTg6NDc6MDAuMDAwWiJ9LCJIYXN0YT8iOnsiaWQiOiJFQkJWIiwidHlwZSI6ImRhdGUiLCJkYXRlIjp7InN0YXJ0IjoiMjAyNC0wMS0yNiIsImVuZCI6bnVsbCwidGltZV96b25lIjpudWxsfX0sIkRlc2NyaXB0aW9uIjp7ImlkIjoiT1pWeCIsInR5cGUiOiJtdWx0aV9zZWxlY3QiLCJtdWx0aV9zZWxlY3QiOltdfSwiRGVzZGU/Ijp7ImlkIjoiVCUzRUYlNUQiLCJ0eXBlIjoiZGF0ZSIsImRhdGUiOnsic3RhcnQiOiIyMDI0LTAxLTIzIiwiZW5kIjpudWxsLCJ0aW1lX3pvbmUiOm51bGx9fSwiRGVzZGU/IHkgSGFzdGE/Ijp7ImlkIjoiJTVEZCU2MGgiLCJ0eXBlIjoiZGF0ZSIsImRhdGUiOnsic3RhcnQiOiIyMDI0LTAxLTI1IiwiZW5kIjpudWxsLCJ0aW1lX3pvbmUiOm51bGx9fSwiUHJveWVjdG8iOnsiaWQiOiJhZUtyIiwidHlwZSI6InNlbGVjdCIsInNlbGVjdCI6eyJpZCI6ImQ0N2Q0NDgwLTA4ZjQtNDE4OS1hZTNiLWFkZjJiMDZkYzVjYiIsIm5hbWUiOiJDb2xsYWJyYSIsImNvbG9yIjoib3JhbmdlIn19LCJUb2RheT8iOnsiaWQiOiJjJTQwJTYwJTdEIiwidHlwZSI6ImZvcm11bGEiLCJmb3JtdWxhIjp7InR5cGUiOiJib29sZWFuIiwiYm9vbGVhbiI6ZmFsc2V9fSwiTmFtZSI6eyJpZCI6InRpdGxlIiwidHlwZSI6InRpdGxlIiwidGl0bGUiOltdfX0sInVybCI6Imh0dHBzOi8vd3d3Lm5vdGlvbi5zby8xY2VhMzJiODQzODY0M2ExYWZlYTZmZGRmYWRmZjQ1ZiIsInB1YmxpY191cmwiOm51bGx9LHsib2JqZWN0IjoicGFnZSIsImlkIjoiY2U2NjRlNzEtNGI5OC00YTQyLTkwMjctMjE2MGIxNDc0MzczIiwiY3JlYXRlZF90aW1lIjoiMjAyNC0wMS0yMlQyMDo1MzowMC4wMDBaIiwibGFzdF9lZGl0ZWRfdGltZSI6IjIwMjQtMDEtMjRUMTU6MTU6MDAuMDAwWiIsImNyZWF0ZWRfYnkiOnsib2JqZWN0IjoidXNlciIsImlkIjoiYzZiOGExZDctYWQyMS00YmFkLTkyYTktNmM1MzEwZWM4MjVhIn0sImxhc3RfZWRpdGVkX2J5Ijp7Im9iamVjdCI6InVzZXIiLCJpZCI6ImM2YjhhMWQ3LWFkMjEtNGJhZC05MmE5LTZjNTMxMGVjODI1YSJ9LCJjb3ZlciI6bnVsbCwiaWNvbiI6bnVsbCwicGFyZW50Ijp7InR5cGUiOiJkYXRhYmFzZV9pZCIsImRhdGFiYXNlX2lkIjoiYjY4ZDExMDYtMWFhZC00M2JkLTg5ZjgtZjUyNWVkZTJiNTY3In0sImFyY2hpdmVkIjpmYWxzZSwicHJvcGVydGllcyI6eyJQZXJzb24iOnsiaWQiOiIlM0QlM0RhJTQwIiwidHlwZSI6InBlb3BsZSIsInBlb3BsZSI6W3sib2JqZWN0IjoidXNlciIsImlkIjoiYzZiOGExZDctYWQyMS00YmFkLTkyYTktNmM1MzEwZWM4MjVhIiwibmFtZSI6IkxvcmVuem8gWnVsdWFnYSIsImF2YXRhcl91cmwiOm51bGwsInR5cGUiOiJwZXJzb24iLCJwZXJzb24iOnt9fV19LCJDcmVhdGVkIjp7ImlkIjoiJTNEJTVETXAiLCJ0eXBlIjoiY3JlYXRlZF90aW1lIiwiY3JlYXRlZF90aW1lIjoiMjAyNC0wMS0yMlQyMDo1MzowMC4wMDBaIn0sIkhhc3RhPyI6eyJpZCI6IkVCQlYiLCJ0eXBlIjoiZGF0ZSIsImRhdGUiOnsic3RhcnQiOiIyMDI0LTAxLTI2IiwiZW5kIjpudWxsLCJ0aW1lX3pvbmUiOm51bGx9fSwiRGVzY3JpcHRpb24iOnsiaWQiOiJPWlZ4IiwidHlwZSI6Im11bHRpX3NlbGVjdCIsIm11bHRpX3NlbGVjdCI6W119LCJEZXNkZT8iOnsiaWQiOiJUJTNFRiU1RCIsInR5cGUiOiJkYXRlIiwiZGF0ZSI6eyJzdGFydCI6IjIwMjQtMDEtMjMiLCJlbmQiOm51bGwsInRpbWVfem9uZSI6bnVsbH19LCJEZXNkZT8geSBIYXN0YT8iOnsiaWQiOiIlNURkJTYwaCIsInR5cGUiOiJkYXRlIiwiZGF0ZSI6eyJzdGFydCI6IjIwMjQtMDEtMjIiLCJlbmQiOiIyMDI0LTAxLTI2IiwidGltZV96b25lIjpudWxsfX0sIlByb3llY3RvIjp7ImlkIjoiYWVLciIsInR5cGUiOiJzZWxlY3QiLCJzZWxlY3QiOnsiaWQiOiJiNDE5Njk2ZC0wNzZkLTQ5YjEtYTIyZC1iYzA0ZDQ1NjUxYzkiLCJuYW1lIjoiUXViaWthIiwiY29sb3IiOiJwdXJwbGUifX0sIlRvZGF5PyI6eyJpZCI6ImMlNDAlNjAlN0QiLCJ0eXBlIjoiZm9ybXVsYSIsImZvcm11bGEiOnsidHlwZSI6ImJvb2xlYW4iLCJib29sZWFuIjp0cnVlfX0sIk5hbWUiOnsiaWQiOiJ0aXRsZSIsInR5cGUiOiJ0aXRsZSIsInRpdGxlIjpbXX19LCJ1cmwiOiJodHRwczovL3d3dy5ub3Rpb24uc28vY2U2NjRlNzE0Yjk4NGE0MjkwMjcyMTYwYjE0NzQzNzMiLCJwdWJsaWNfdXJsIjpudWxsfSx7Im9iamVjdCI6InBhZ2UiLCJpZCI6ImNjODQ5ZjIwLTg2ZTQtNGRjMi1iMmFjLTNlZmIwNTI0MWI0ZSIsImNyZWF0ZWRfdGltZSI6IjIwMjQtMDEtMTlUMjE6Mjk6MDAuMDAwWiIsImxhc3RfZWRpdGVkX3RpbWUiOiIyMDI0LTAxLTI0VDAyOjU0OjAwLjAwMFoiLCJjcmVhdGVkX2J5Ijp7Im9iamVjdCI6InVzZXIiLCJpZCI6ImM2YjhhMWQ3LWFkMjEtNGJhZC05MmE5LTZjNTMxMGVjODI1YSJ9LCJsYXN0X2VkaXRlZF9ieSI6eyJvYmplY3QiOiJ1c2VyIiwiaWQiOiJjNmI4YTFkNy1hZDIxLTRiYWQtOTJhOS02YzUzMTBlYzgyNWEifSwiY292ZXIiOm51bGwsImljb24iOm51bGwsInBhcmVudCI6eyJ0eXBlIjoiZGF0YWJhc2VfaWQiLCJkYXRhYmFzZV9pZCI6ImI2OGQxMTA2LTFhYWQtNDNiZC04OWY4LWY1MjVlZGUyYjU2NyJ9LCJhcmNoaXZlZCI6ZmFsc2UsInByb3BlcnRpZXMiOnsiUGVyc29uIjp7ImlkIjoiJTNEJTNEYSU0MCIsInR5cGUiOiJwZW9wbGUiLCJwZW9wbGUiOlt7Im9iamVjdCI6InVzZXIiLCJpZCI6IjdiNmEwODM5LWQ1YWQtNDYzNi05NTA5LTg0MTFjYzcwNjg4ZCIsIm5hbWUiOiJGZWxpcGUgR3V6bcOhbiIsImF2YXRhcl91cmwiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vYS9BQVRYQUp6QnNxMTRVNjd4aTB5bHNrZC1EdHhuTlRDekw1TGVyaktETFRlYj1zMTAwIiwidHlwZSI6InBlcnNvbiIsInBlcnNvbiI6e319XX0sIkNyZWF0ZWQiOnsiaWQiOiIlM0QlNURNcCIsInR5cGUiOiJjcmVhdGVkX3RpbWUiLCJjcmVhdGVkX3RpbWUiOiIyMDI0LTAxLTE5VDIxOjI5OjAwLjAwMFoifSwiSGFzdGE/Ijp7ImlkIjoiRUJCViIsInR5cGUiOiJkYXRlIiwiZGF0ZSI6eyJzdGFydCI6IjIwMjQtMDEtMjUiLCJlbmQiOm51bGwsInRpbWVfem9uZSI6bnVsbH19LCJEZXNjcmlwdGlvbiI6eyJpZCI6Ik9aVngiLCJ0eXBlIjoibXVsdGlfc2VsZWN0IiwibXVsdGlfc2VsZWN0IjpbXX0sIkRlc2RlPyI6eyJpZCI6IlQlM0VGJTVEIiwidHlwZSI6ImRhdGUiLCJkYXRlIjp7InN0YXJ0IjoiMjAyNC0wMS0yMiIsImVuZCI6bnVsbCwidGltZV96b25lIjpudWxsfX0sIkRlc2RlPyB5IEhhc3RhPyI6eyJpZCI6IiU1RGQlNjBoIiwidHlwZSI6ImRhdGUiLCJkYXRlIjp7InN0YXJ0IjoiMjAyNC0wMS0yMiIsImVuZCI6IjIwMjQtMDEtMjUiLCJ0aW1lX3pvbmUiOm51bGx9fSwiUHJveWVjdG8iOnsiaWQiOiJhZUtyIiwidHlwZSI6InNlbGVjdCIsInNlbGVjdCI6eyJpZCI6ImQ0N2Q0NDgwLTA4ZjQtNDE4OS1hZTNiLWFkZjJiMDZkYzVjYiIsIm5hbWUiOiJDb2xsYWJyYSIsImNvbG9yIjoib3JhbmdlIn19LCJUb2RheT8iOnsiaWQiOiJjJTQwJTYwJTdEIiwidHlwZSI6ImZvcm11bGEiLCJmb3JtdWxhIjp7InR5cGUiOiJib29sZWFuIiwiYm9vbGVhbiI6dHJ1ZX19LCJOYW1lIjp7ImlkIjoidGl0bGUiLCJ0eXBlIjoidGl0bGUiLCJ0aXRsZSI6W119fSwidXJsIjoiaHR0cHM6Ly93d3cubm90aW9uLnNvL2NjODQ5ZjIwODZlNDRkYzJiMmFjM2VmYjA1MjQxYjRlIiwicHVibGljX3VybCI6bnVsbH1dLCJuZXh0X2N1cnNvciI6bnVsbCwiaGFzX21vcmUiOmZhbHNlLCJ0eXBlIjoicGFnZV9vcl9kYXRhYmFzZSIsInBhZ2Vfb3JfZGF0YWJhc2UiOnt9LCJyZXF1ZXN0X2lkIjoiYjkxNWU5NjYtNGM4Ni00ZGQ3LWFlZTktZTZiMjk2MDMxZjc3In0=
   recorded_at: Wed, 24 Jan 2024 15:21:27 GMT
+- request:
+    method: post
+    uri: https://api.notion.com/v1/databases/8187370982134ed099f9d14385aa81c9/query
+    body:
+      encoding: UTF-8
+      string: '{"filter":{"and":[{"property":"Desde?","date":{"on_or_before":"2024-04-08"}},{"property":"Hasta?","date":{"on_or_after":"2024-04-08"}}]}}'
+    headers:
+      Authorization:
+      - Bearer secret_K5UCqm27GvAscTlaGJmS2se4fyM1K7is3OIZMw03NaC
+      Content-Type:
+      - application/json
+      Notion-Version:
+      - '2022-06-28'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Apr 2024 22:07:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      X-Notion-Request-Id:
+      - 2c6398e6-2163-49ac-961f-3d394f12a49f
+      Etag:
+      - W/"c9b-zC4LpTN6CmJl9u7AuCQd2NjMGn0"
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=P6MJX6fXfzsolIESXzhfsVZ_plmm8zMqT6.i3HUvYZw-1712614076-1.0.1.1-om.VM.xPaTFOTu8TJfuX46L9kl0Gd20LAUiYEeY0mgHLlLL5AYAud7w7ldUAbobhZ7QKL6ZgWdPKvWKKh4Eylw;
+        path=/; expires=Mon, 08-Apr-24 22:37:56 GMT; domain=.notion.com; HttpOnly;
+        Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 871592bb6bd4f7b8-BOG
+    body:
+      encoding: ASCII-8BIT
+      string: '{"object":"list","results":[{"object":"page","id":"f37f592a-fd4b-4b7a-8d02-1ab6284d87f2","created_time":"2024-02-26T21:39:00.000Z","last_edited_time":"2024-04-08T22:07:00.000Z","created_by":{"object":"user","id":"7b6a0839-d5ad-4636-9509-8411cc70688d"},"last_edited_by":{"object":"user","id":"7b6a0839-d5ad-4636-9509-8411cc70688d"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"81873709-8213-4ed0-99f9-d14385aa81c9"},"archived":false,"in_trash":false,"properties":{"Desde?":{"id":"TU%7DA","type":"date","date":{"start":"2024-04-08T14:00:00.000-05:00","end":null,"time_zone":null}},"Hasta?":{"id":"XNm_","type":"date","date":{"start":"2024-04-08T18:00:00.000-05:00","end":null,"time_zone":null}},"Description":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Luis","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Luis","href":null}]}},"url":"https://www.notion.so/Luis-f37f592afd4b4b7a8d021ab6284d87f2","public_url":null},{"object":"page","id":"44ad84ec-caac-494c-9415-0afe88749f48","created_time":"2024-02-26T21:39:00.000Z","last_edited_time":"2024-04-08T22:07:00.000Z","created_by":{"object":"user","id":"7b6a0839-d5ad-4636-9509-8411cc70688d"},"last_edited_by":{"object":"user","id":"7b6a0839-d5ad-4636-9509-8411cc70688d"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"81873709-8213-4ed0-99f9-d14385aa81c9"},"archived":false,"in_trash":false,"properties":{"Desde?":{"id":"TU%7DA","type":"date","date":{"start":"2024-04-08","end":null,"time_zone":null}},"Hasta?":{"id":"XNm_","type":"date","date":{"start":"2024-04-12","end":null,"time_zone":null}},"Description":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Lorenzo","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Lorenzo","href":null}]}},"url":"https://www.notion.so/Lorenzo-44ad84eccaac494c94150afe88749f48","public_url":null},{"object":"page","id":"4b8a9481-2c47-466d-bc98-2b65b74c648f","created_time":"2024-02-26T21:38:00.000Z","last_edited_time":"2024-04-08T22:07:00.000Z","created_by":{"object":"user","id":"7b6a0839-d5ad-4636-9509-8411cc70688d"},"last_edited_by":{"object":"user","id":"7b6a0839-d5ad-4636-9509-8411cc70688d"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"81873709-8213-4ed0-99f9-d14385aa81c9"},"archived":false,"in_trash":false,"properties":{"Desde?":{"id":"TU%7DA","type":"date","date":{"start":"2024-04-08","end":null,"time_zone":null}},"Hasta?":{"id":"XNm_","type":"date","date":{"start":"2024-04-08","end":null,"time_zone":null}},"Description":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Felipe
+        Guzman","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Felipe
+        Guzman","href":null}]}},"url":"https://www.notion.so/Felipe-Guzman-4b8a94812c47466dbc982b65b74c648f","public_url":null}],"next_cursor":null,"has_more":false,"type":"page_or_database","page_or_database":{},"request_id":"2c6398e6-2163-49ac-961f-3d394f12a49f"}'
+  recorded_at: Mon, 08 Apr 2024 22:07:56 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
Closes #11

## Description
In this PR:
- the column used to fetch the user's names for the PTO use cases was changed from "Person" to "Description".
- the support email date format was updated to use %d instead of %e ([reference](https://ruby-doc.org/core-2.7.1/Time.html#method-i-strftime))
- the tests were updated