### PR TITLE
Solve #22 - Use format method

### DIFF
--- a/lib/bas/use_cases/use_case.rb
+++ b/lib/bas/use_cases/use_case.rb
@@ -32,7 +32,7 @@ module UseCases
 
       serialization = serialize.execute(response)
 
-      format_response = valid_format_response(serialization)
+      format_response = formatter.format(serialization)
 
       process_response = process.execute(format_response)
 


### PR DESCRIPTION
Solve #22

## Description
An error occurred during the execution of certain use cases. The error was caused by improper usage of the format method within the validation of the use case class. In this PR, the validation has been removed, and the format method is now being utilized instead.