### PR TITLE
Solve #31 - Refactor Birthday today Use Case

### DIFF
--- a/lib/v2/bot/fetch_birthdays_from_notion.rb
+++ b/lib/v2/bot/fetch_birthdays_from_notion.rb
@@ -26,7 +26,7 @@ module Bot
   #         user: "postgres",
   #         password: "postgres"
   #       },
-  #       db_table: "birthdays",
+  #       db_table: "use_cases",
   #       bot_name: "FetchBirthdaysFromNotion"
   #     }
   #   }
@@ -43,7 +43,7 @@ module Bot
       reader.execute
     end
 
-    # Process function to execute the Notion utility to fetch PTO's from the notion database
+    # Process function to execute the Notion utility to fetch birthdays from a notion database
     #
     def process(_read_response)
       response = Utils::Notion::Request.execute(params)

--- a/lib/v2/bot/fetch_birthdays_from_notion.rb
+++ b/lib/v2/bot/fetch_birthdays_from_notion.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/default"
+require_relative "../utils/notion/request"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::FetchBirthdaysFromNotion class serves as a bot implementation to read birthdays from a
+  # notion database and write them on a PostgresDB table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     process_options: {
+  #       database_id: "notion database id",
+  #       secret: "notion secret"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "host",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "birthdays",
+  #       bot_name: "FetchBirthdaysFromNotion"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FetchBirthdaysFromNotion.new(options)
+  #   bot.execute
+  #
+  class FetchBirthdaysFromNotion < Bot::Base
+    # Read function to execute the default Read component
+    #
+    def read
+      reader = Read::Default.new
+
+      reader.execute
+    end
+
+    # Process function to execute the Notion utility to fetch PTO's from the notion database
+    #
+    def process(_read_response)
+      response = Utils::Notion::Request.execute(params)
+
+      if response.code == 200
+        birthdays_list = normalize_response(response.parsed_response["results"])
+
+        { success: { birthdays: birthdays_list } }
+      else
+        { error: { message: response.parsed_response, status_code: response.code } }
+      end
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write(process_response)
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def params
+      {
+        endpoint: "databases/#{process_options[:database_id]}/query",
+        secret: process_options[:secret],
+        method: "post",
+        body:
+      }
+    end
+
+    def body
+      today = Time.now.utc.strftime("%F").to_s
+
+      {
+        filter: {
+          or: [
+            { property: "BD_this_year", date: { equals: today } }
+          ]
+        }
+      }
+    end
+
+    def normalize_response(results)
+      return [] if results.nil?
+
+      results.map do |value|
+        birthday_fields = value["properties"]
+
+        {
+          "name" => extract_rich_text_field_value(birthday_fields["Complete Name"]),
+          "birthday_date" => extract_date_field_value(birthday_fields["BD_this_year"])
+        }
+      end
+    end
+
+    def extract_rich_text_field_value(data)
+      data["rich_text"][0]["plain_text"]
+    end
+
+    def extract_date_field_value(data)
+      data["formula"]["date"]["start"]
+    end
+  end
+end

--- a/lib/v2/bot/format_birthdays.rb
+++ b/lib/v2/bot/format_birthdays.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::FormatBirthdays class serves as a bot implementation to read birthdays from a
+  # PostgresDB database, format them with a specific template, and write them on a PostgresDB
+  # table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases",
+  #       bot_name: "FetchBirthdaysFromNotion"
+  #     },
+  #     process_options: {
+  #       template: "birthday template message"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases",
+  #       bot_name: "FormatBirthdays"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FormatBirthdays.new(options)
+  #   bot.execute
+  #
+  class FormatBirthdays < Bot::Base
+    BIRTHDAY_ATTRIBUTES = %w[name birthday_date].freeze
+
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options)
+
+      reader.execute
+    end
+
+    # Process function to format the notification using a template
+    #
+    def process(read_response)
+      return { success: { notification: "" } } if read_response.data.nil? || read_response.data["birthdays"] == []
+
+      birthdays_list = read_response.data["birthdays"]
+
+      notification = birthdays_list.reduce("") do |payload, birthday|
+        "#{payload} #{build_template(BIRTHDAY_ATTRIBUTES, birthday)} \n"
+      end
+
+      { success: { notification: } }
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write(process_response)
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def build_template(attributes, instance)
+      template = process_options[:template]
+
+      attributes.reduce(template) do |formated_template, attribute|
+        formated_template.gsub("<#{attribute}>", instance[attribute].to_s)
+      end
+    end
+  end
+end

--- a/spec/v2/bot/fetch_birthdays_from_notion_spec.rb
+++ b/spec/v2/bot/fetch_birthdays_from_notion_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "v2/bot/fetch_birthdays_from_notion"
+
+RSpec.describe Bot::FetchBirthdaysFromNotion do
+  before do
+    config = {
+      process_options: {
+        database_id: "database_id",
+        secret: "secret"
+      },
+      write_options: {
+        connection: {
+          host: "host",
+          port: 5432,
+          dbname: "bas",
+          user: "postgres",
+          password: "postgres"
+        },
+        db_table: "use_cases",
+        bot_name: "FetchBirthdaysFromNotion"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(1).arguments }
+    it { expect(@bot).to respond_to(:write).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    it { expect(@bot.read).to be_a Read::Types::Response }
+  end
+
+  describe ".process" do
+    let(:birthday) do
+      {
+        "properties" => {
+          "Complete Name" => { "rich_text" => [{ "plain_text" => "John Doe" }] },
+          "BD_this_year" => { "formula" => { "date" => { "start" => "2024-05-01" } } }
+        }
+      }
+    end
+
+    let(:formatted_birthday) do
+      {
+        "name" => "John Doe",
+        "birthday_date" => "2024-05-01"
+      }
+    end
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    let(:response) { double("http_response") }
+
+    before do
+      @read_response = Read::Types::Response.new
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "returns a success hash with the list of formatted birthdays" do
+      allow(response).to receive(:code).and_return(200)
+      allow(response).to receive(:parsed_response).and_return({ "results" => [birthday] })
+
+      processed = @bot.process(@read_response)
+
+      expect(processed).to eq({ success: { birthdays: [formatted_birthday] } })
+    end
+
+    it "returns an error hash with the error message" do
+      allow(response).to receive(:code).and_return(404)
+      allow(response).to receive(:parsed_response).and_return(error_response)
+
+      processed = @bot.process(@read_response)
+
+      expect(processed).to eq({ error: { message: error_response, status_code: 404 } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:formatted_birthday) do
+      {
+        "name" => "John Doe",
+        "birthday_date" => "2024-05-01"
+      }
+    end
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      process_response = { success: { birthdays: [formatted_birthday] } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+  end
+end

--- a/spec/v2/bot/format_birthdays_spec.rb
+++ b/spec/v2/bot/format_birthdays_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "v2/bot/format_birthdays"
+
+RSpec.describe Bot::FormatBirthdays do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "use_cases",
+        bot_name: "FetchBirthdaysFromNotion"
+      },
+      process_options: {
+        template: "<name>, Wishing you a very happy birthday!"
+      },
+      write_options: {
+        connection:,
+        db_table: "use_cases",
+        bot_name: "FormatBirthdays"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(1).arguments }
+    it { expect(@bot).to respond_to(:write).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:birthdays_results) do
+      "{\"birthdays\": [\
+      {\"name\": \"John Doe\", \"birthday_date\": \"2024-05-03\"},\
+      {\"name\": \"Jane Doe\", \"birthday_date\": \"2024-05-03\"}\
+      ]}"
+    end
+
+    let(:formatted_birthdays) do
+      { "birthdays" => [{ "name" => "John Doe", "birthday_date" => "2024-05-03" },
+                        { "name" => "Jane Doe", "birthday_date" => "2024-05-03" }] }
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[birthdays_results]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_birthdays)
+    end
+  end
+
+  describe ".process" do
+    let(:birthdays) do
+      [{
+        "name" => "John Doe",
+        "birthday_date" => "2024-05-01"
+      },
+       {
+         "name" => "Jane Doe",
+         "birthday_date" => "2024-05-01"
+       }]
+    end
+
+    let(:formatted_birthday) do
+      " John Doe, Wishing you a very happy birthday! \n Jane Doe, Wishing you a very happy birthday! \n"
+    end
+
+    it "returns an empty success hash when the birthdays list is empty" do
+      read_response = Read::Types::Response.new({ "birthdays" => [] })
+
+      expect(@bot.process(read_response)).to eq({ success: { notification: "" } })
+    end
+
+    it "returns an empty success hash when the record was not found" do
+      read_response = Read::Types::Response.new(nil)
+
+      expect(@bot.process(read_response)).to eq({ success: { notification: "" } })
+    end
+
+    it "returns a success hash with the list of formatted birthdays" do
+      read_response = Read::Types::Response.new({ "birthdays" => birthdays })
+      processed = @bot.process(read_response)
+
+      expect(processed).to eq({ success: { notification: formatted_birthday } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:formatted_birthday) do
+      " John Doe, Wishing you a very happy birthday! \n Jane Doe, Wishing you a very happy birthday! \n"
+    end
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      process_response = { success: { notification: formatted_birthday } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #31 

## Context
On this PR, the today birthdays use case was refactored. For this:
1. A new BOT called FetchBirthdaysFromNotion was added to fetch birthday data from notion. 
2. A new BOT called FormatBirthdays was added to format birthday notification messages.

Example of us:
```ruby
# FetchBirthdaysFromNotion
options = {
  process_options: {
    database_id: "notion database id",
    secret: "notion secret"
  },
  write_options: {
    connection: {
      host: "host",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "use_cases",
    bot_name: "FetchBirthdaysFromNotion"
  }
}

bot = Bot::FetchBirthdaysFromNotion.new(options)
bot.execute

# FormatBirthdays
options = {
  read_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "use_cases",
    bot_name: "FetchBirthdaysFromNotion"
  },
  process_options: {
    template: "birthday template message"
  },
  write_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "use_cases",
    bot_name: "FormatBirthdays"
  }
}

bot = Bot::FormatBirthdays.new(options)
bot.execute
```

