### PR TITLE
Solve #33 - Refactor WIP limit Use Case

### DIFF
--- a/lib/v2/bot/compare_wip_limit_count.rb
+++ b/lib/v2/bot/compare_wip_limit_count.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::CompareWipLimitCount class serves as a bot implementation to read domains wip limits and
+  # counts from a PostgresDB database, compare the values to find exceeded counts, and write them on
+  # a PostgresDB table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases",
+  #       bot_name: "FetchDomainsWipLimitFromNotion"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases",
+  #       bot_name: "CompareWipLimitCount"
+  #     }
+  #   }
+  #
+  #   bot = Bot::CompareWipLimitCount.new(options)
+  #   bot.execute
+  #
+  class CompareWipLimitCount < Bot::Base
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options)
+
+      reader.execute
+    end
+
+    # Process function to compare the domains wip counts and limits
+    #
+    def process(read_response)
+      return { success: { exceeded_domain_count: {} } } if unprocessable_response(read_response.data)
+
+      domains_limits = read_response.data["domains_limits"]
+      domain_wip_count = read_response.data["domain_wip_count"]
+
+      exceeded_domain_count = exceedded_counts(domains_limits, domain_wip_count)
+
+      { success: { exceeded_domain_count: } }
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write(process_response)
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def unprocessable_response(read_data)
+      read_data.nil? || read_data == {} || read_data["domains_limits"] == [] || read_data["domain_wip_count"] == []
+    end
+
+    def exceedded_counts(limits, counts)
+      counts.to_a.map do |domain_wip_count|
+        domain, count = domain_wip_count
+        domain_limit = limits[domain]
+
+        { domain:, exceeded: count - domain_limit } if count > domain_limit
+      end.compact
+    end
+  end
+end

--- a/lib/v2/bot/fetch_domains_wip_counts_from_notion.rb
+++ b/lib/v2/bot/fetch_domains_wip_counts_from_notion.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/default"
+require_relative "../utils/notion/request"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::FetchDomainsWipCountsFromNotion class serves as a bot implementation to fetch work items
+  # in progress or in hold from a Notion database, count how many are by domain, and write them on a
+  # PostgresDB table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     process_options: {
+  #       database_id: "notion database id",
+  #       secret: "notion secret"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "host",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases",
+  #       bot_name: "FetchDomainsWipCountsFromNotion"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FetchDomainsWipCountsFromNotion.new(options)
+  #   bot.execute
+  #
+  class FetchDomainsWipCountsFromNotion < Bot::Base
+    # Read function to execute the default Read component
+    #
+    def read
+      reader = Read::Default.new
+
+      reader.execute
+    end
+
+    # Process function to execute the Notion utility to fetch work item from the notion database
+    #
+    def process(_read_response)
+      response = Utils::Notion::Request.execute(params)
+
+      if response.code == 200
+        work_items_domains = normalize_response(response.parsed_response["results"])
+        domain_wip_count = count_domain_items(work_items_domains)
+
+        { success: { domain_wip_count: } }
+      else
+        { error: { message: response.parsed_response, status_code: response.code } }
+      end
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write(process_response)
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def params
+      {
+        endpoint: "databases/#{process_options[:database_id]}/query",
+        secret: process_options[:secret],
+        method: "post",
+        body:
+      }
+    end
+
+    def body
+      {
+        filter: {
+          "and": [
+            { property: "OK", formula: { string: { contains: "✅" } } },
+            { "or": status_conditions }
+          ]
+        }
+      }
+    end
+
+    def status_conditions
+      [
+        { property: "Status", status: { equals: "In Progress" } },
+        { property: "Status", status: { equals: "On Hold" } }
+      ]
+    end
+
+    def normalize_response(results)
+      return [] if results.nil?
+
+      results.map do |pto|
+        work_item_fields = pto["properties"]
+
+        {
+          "domain" => extract_domain_field_value(work_item_fields["Responsible domain"])
+        }
+      end
+    end
+
+    def extract_domain_field_value(data)
+      data["select"]["name"]
+    end
+
+    def count_domain_items(work_items_list)
+      domain_work_items = work_items_list.group_by { |work_item| work_item["domain"] }
+
+      domain_work_items.transform_values(&:count)
+    end
+  end
+end

--- a/lib/v2/bot/fetch_domains_wip_limit_from_notion.rb
+++ b/lib/v2/bot/fetch_domains_wip_limit_from_notion.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/default"
+require_relative "../utils/notion/request"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::FetchDomainsWipLimitFromNotion class serves as a bot implementation to fetch domains wip
+  # limits from a Notion database, merge them with the count of how many are by domain, and write them
+  # on a PostgresDB table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "host",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases",
+  #       bot_name: "FetchDomainsWipCountsFromNotion"
+  #     },
+  #     process_options: {
+  #       database_id: "notion database id",
+  #       secret: "notion secret"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "host",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases",
+  #       bot_name: "FetchDomainsWipLimitFromNotion"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FetchDomainsWipLimitFromNotion.new(options)
+  #   bot.execute
+  #
+  class FetchDomainsWipLimitFromNotion < Bot::Base
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options)
+
+      reader.execute
+    end
+
+    # Process function to execute the Notion utility to fetch domain wip limits from the notion database
+    #
+    def process(read_response)
+      response = Utils::Notion::Request.execute(params)
+
+      if response.code == 200
+        domains_limits = normalize_response(response.parsed_response["results"])
+
+        wip_limit_data = wip_count(read_response).merge({ domains_limits: })
+
+        { success: wip_limit_data }
+      else
+        { error: { message: response.parsed_response, status_code: response.code } }
+      end
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write(process_response)
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def params
+      {
+        endpoint: "databases/#{process_options[:database_id]}/query",
+        secret: process_options[:secret],
+        method: "post",
+        body:
+      }
+    end
+
+    def body
+      {
+        filter: {
+          property: "WIP + On Hold limit",
+          number: { is_not_empty: true }
+        }
+      }
+    end
+
+    def normalize_response(results)
+      return [] if results.nil?
+
+      results.reduce({}) do |domains_limits, domain_wip_limit|
+        domain_fields = domain_wip_limit["properties"]
+
+        domain = extract_domain_name_value(domain_fields["Name"])
+        limit = extract_domain_limit_value(domain_fields["WIP + On Hold limit"])
+
+        domains_limits.merge({ domain => limit })
+      end
+    end
+
+    def extract_domain_name_value(data)
+      data["title"].first["plain_text"]
+    end
+
+    def extract_domain_limit_value(data)
+      data["number"]
+    end
+
+    def wip_count(read_response)
+      read_response.data.nil? ? {} : read_response.data
+    end
+  end
+end

--- a/lib/v2/bot/format_wip_limit_exceeded.rb
+++ b/lib/v2/bot/format_wip_limit_exceeded.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::FormatWipLimitExceeded class serves as a bot implementation to read exceeded domain wip
+  # counts by limits from a PostgresDB database, format them with a specific template, and write them
+  # on a PostgresDB table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases",
+  #       bot_name: "CompareWipLimitCount"
+  #     },
+  #     process_options: {
+  #       template: "exceeded wip limit template message"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases",
+  #       bot_name: "FormatWipLimitExceeded"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FormatWipLimitExceeded.new(options)
+  #   bot.execute
+  #
+  class FormatWipLimitExceeded < Bot::Base
+    WIP_LIMIT_ATTRIBUTES = %w[domain exceeded].freeze
+
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options)
+
+      reader.execute
+    end
+
+    # Process function to format the notification using a template
+    #
+    def process(read_response)
+      return { success: { notification: "" } } if unprocessable_response(read_response.data)
+
+      exceedded_limits_list = read_response.data["exceeded_domain_count"]
+
+      notification = exceedded_limits_list.reduce("") do |payload, exceedded_limit|
+        "#{payload} #{build_template(WIP_LIMIT_ATTRIBUTES, exceedded_limit)} \n"
+      end
+
+      { success: { notification: } }
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write(process_response)
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def unprocessable_response(read_data)
+      read_data.nil? || read_data["exceeded_domain_count"] == {}
+    end
+
+    def build_template(attributes, instance)
+      template = process_options[:template]
+
+      attributes.reduce(template) do |formated_template, attribute|
+        formated_template.gsub("<#{attribute}>", instance[attribute].to_s)
+      end
+    end
+  end
+end

--- a/spec/v2/bot/compare_wip_limit_count_spec.rb
+++ b/spec/v2/bot/compare_wip_limit_count_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "v2/bot/compare_wip_limit_count"
+
+RSpec.describe Bot::CompareWipLimitCount do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "use_cases",
+        bot_name: "FetchDomainsWipLimitFromNotion"
+      },
+      write_options: {
+        connection:,
+        db_table: "use_cases",
+        bot_name: "CompareWipLimitCount"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(1).arguments }
+    it { expect(@bot).to respond_to(:write).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:domains_wip_limit_counts_results) do
+      "{\"domains_limits\": {\"ops\": 1, \"engineering\": 1}, \"domain_wip_count\": {\"ops\": 1, \"engineering\": 2}}"
+    end
+
+    let(:formatted_domains_wip_limit_counts) do
+      {
+        "domains_limits" => { "ops" => 1, "engineering" => 1 }, "domain_wip_count" => { "ops" => 1, "engineering" => 2 }
+      }
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[domains_wip_limit_counts_results]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_domains_wip_limit_counts)
+    end
+  end
+
+  describe ".process" do
+    let(:formatted_domains_wip_limit_counts) do
+      {
+        "domains_limits" => { "ops" => 1, "engineering" => 1 }, "domain_wip_count" => { "ops" => 1, "engineering" => 2 }
+      }
+    end
+
+    let(:exceeded_domain_count) { [{ domain: "engineering", exceeded: 1 }] }
+
+    it "returns an empty success hash when the record was not found" do
+      read_response = Read::Types::Response.new(nil)
+
+      expect(@bot.process(read_response)).to eq({ success: { exceeded_domain_count: {} } })
+    end
+
+    it "returns an empty success hash when the limits count hash is empty" do
+      read_response = Read::Types::Response.new({})
+
+      expect(@bot.process(read_response)).to eq({ success: { exceeded_domain_count: {} } })
+    end
+
+    it "returns an empty success hash when the domains_limits list is empty" do
+      read_response = Read::Types::Response.new({ "domains_limits" => [] })
+
+      expect(@bot.process(read_response)).to eq({ success: { exceeded_domain_count: {} } })
+    end
+
+    it "returns an empty success hash when the domain_wip_count list is empty" do
+      read_response = Read::Types::Response.new({ "domains_limits" => [{}], "domain_wip_count" => [] })
+
+      expect(@bot.process(read_response)).to eq({ success: { exceeded_domain_count: {} } })
+    end
+
+    it "returns a success hash with the hash of wip limits counts" do
+      read_response = Read::Types::Response.new(formatted_domains_wip_limit_counts)
+      processed = @bot.process(read_response)
+
+      expect(processed).to eq({ success: { exceeded_domain_count: } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:exceeded_domain_count) { [{ domain: "engineering", exceeded: 1 }] }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      process_response = { success: { exceeded_domain_count: } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+  end
+end

--- a/spec/v2/bot/compare_wip_limit_count_spec.rb
+++ b/spec/v2/bot/compare_wip_limit_count_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Bot::CompareWipLimitCount do
       allow(@pg_result).to receive(:values).and_return([[domains_wip_limit_counts_results]])
     end
 
-    it "read the notification from the postgres database" do
+    it "read the wip's count and limits by domain from the postgres database" do
       read = @bot.read
 
       expect(read).to be_a Read::Types::Response

--- a/spec/v2/bot/fetch_domains_wip_counts_from_notion_spec.rb
+++ b/spec/v2/bot/fetch_domains_wip_counts_from_notion_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "v2/bot/fetch_domains_wip_counts_from_notion"
+
+RSpec.describe Bot::FetchDomainsWipCountsFromNotion do
+  before do
+    config = {
+      process_options: {
+        database_id: "database_id",
+        secret: "secret"
+      },
+      write_options: {
+        connection: {
+          host: "host",
+          port: 5432,
+          dbname: "bas",
+          user: "postgres",
+          password: "postgres"
+        },
+        db_table: "use_cases",
+        bot_name: "FetchDomainsWipCountsFromNotion"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(1).arguments }
+    it { expect(@bot).to respond_to(:write).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    it { expect(@bot.read).to be_a Read::Types::Response }
+  end
+
+  describe ".process" do
+    let(:work_items) do
+      [
+        { "properties" => { "Responsible domain" => { "select" => { "name" => "ops" } } } },
+        { "properties" => { "Responsible domain" => { "select" => { "name" => "marketing" } } } },
+        { "properties" => { "Responsible domain" => { "select" => { "name" => "engineering" } } } },
+        { "properties" => { "Responsible domain" => { "select" => { "name" => "engineering" } } } }
+      ]
+    end
+
+    let(:formatted_wip_count) { { "ops" => 1, "marketing" => 1, "engineering" => 2 } }
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+    let(:response) { double("http_response") }
+
+    before do
+      @read_response = Read::Types::Response.new
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "returns a success hash with the wip's count by domain" do
+      allow(response).to receive(:code).and_return(200)
+      allow(response).to receive(:parsed_response).and_return({ "results" => work_items })
+
+      processed = @bot.process(@read_response)
+
+      expect(processed).to eq({ success: { domain_wip_count: formatted_wip_count } })
+    end
+
+    it "returns an error hash with the error message" do
+      allow(response).to receive(:code).and_return(404)
+      allow(response).to receive(:parsed_response).and_return(error_response)
+
+      processed = @bot.process(@read_response)
+
+      expect(processed).to eq({ error: { message: error_response, status_code: 404 } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:formatted_wip_count) { { "ops" => 1, "marketing" => 1, "engineering" => 2 } }
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      process_response = { success: { domain_wip_count: formatted_wip_count } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+  end
+end

--- a/spec/v2/bot/fetch_domains_wip_limit_from_notion_spec.rb
+++ b/spec/v2/bot/fetch_domains_wip_limit_from_notion_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Bot::FetchDomainsWipLimitFromNotion do
       allow(@pg_result).to receive(:values).and_return([[wip_count_results]])
     end
 
-    it "read the notification from the postgres database" do
+    it "read the domains wip counts from the postgres database" do
       read = @bot.read
 
       expect(read).to be_a Read::Types::Response
@@ -99,7 +99,7 @@ RSpec.describe Bot::FetchDomainsWipLimitFromNotion do
       allow(HTTParty).to receive(:send).and_return(response)
     end
 
-    it "returns a success hash with the wip's count by domain" do
+    it "returns a success hash with the wip's count and limits by domain" do
       allow(response).to receive(:code).and_return(200)
       allow(response).to receive(:parsed_response).and_return({ "results" => domain_limits })
 

--- a/spec/v2/bot/fetch_domains_wip_limit_from_notion_spec.rb
+++ b/spec/v2/bot/fetch_domains_wip_limit_from_notion_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "v2/bot/fetch_domains_wip_limit_from_notion"
+
+RSpec.describe Bot::FetchDomainsWipLimitFromNotion do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "use_cases",
+        bot_name: "FetchDomainsWipCountsFromNotion"
+      },
+      process_options: {
+        database_id: "database_id",
+        secret: "secret"
+      },
+      write_options: {
+        connection: {
+          host: "host",
+          port: 5432,
+          dbname: "bas",
+          user: "postgres",
+          password: "postgres"
+        },
+        db_table: "use_cases",
+        bot_name: "FetchDomainsWipLimitFromNotion"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(1).arguments }
+    it { expect(@bot).to respond_to(:write).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:wip_count_results) { "{\"domain_wip_count\": {\"kommit.ops\": 7, \"kommit.engineering\": 11}}" }
+    let(:formatted_wip_count) { { "domain_wip_count" => { "kommit.ops" => 7, "kommit.engineering" => 11 } } }
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[wip_count_results]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_wip_count)
+    end
+  end
+
+  describe ".process" do
+    let(:domain_limits) do
+      [
+        { "properties" => { "Name" => { "title" => [{ "plain_text" => "ops" }] },
+                            "WIP + On Hold limit" => { "number" => 1 } } },
+        { "properties" => { "Name" => { "title" => [{ "plain_text" => "marketing" }] },
+                            "WIP + On Hold limit" => { "number" => 1 } } },
+        { "properties" => { "Name" => { "title" => [{ "plain_text" => "engineering" }] },
+                            "WIP + On Hold limit" => { "number" => 1 } } }
+      ]
+    end
+
+    let(:domains_wip_count) { { "domain_wip_count" => { "ops" => 1, "marketing" => 1, "engineering" => 2 } } }
+    let(:formatted_domain_wip_limits_counts) do
+      { domains_limits: { "ops" => 1, "marketing" => 1, "engineering" => 1 } }.merge(domains_wip_count)
+    end
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+    let(:response) { double("http_response") }
+
+    before do
+      @read_response = Read::Types::Response.new(domains_wip_count)
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "returns a success hash with the wip's count by domain" do
+      allow(response).to receive(:code).and_return(200)
+      allow(response).to receive(:parsed_response).and_return({ "results" => domain_limits })
+
+      processed = @bot.process(@read_response)
+
+      expect(processed).to eq({ success: formatted_domain_wip_limits_counts })
+    end
+
+    it "returns an error hash with the error message" do
+      allow(response).to receive(:code).and_return(404)
+      allow(response).to receive(:parsed_response).and_return(error_response)
+
+      processed = @bot.process(@read_response)
+
+      expect(processed).to eq({ error: { message: error_response, status_code: 404 } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:domains_wip_count) { { "domain_wip_count" => { "ops" => 1, "marketing" => 1, "engineering" => 2 } } }
+    let(:formatted_domain_wip_limits_counts) do
+      { domains_limits: { "ops" => 1, "marketing" => 1, "engineering" => 1 } }.merge(domains_wip_count)
+    end
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      process_response = { success: formatted_domain_wip_limits_counts }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+  end
+end

--- a/spec/v2/bot/format_wip_limit_exceeded_spec.rb
+++ b/spec/v2/bot/format_wip_limit_exceeded_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Bot::FormatWipLimitExceeded do
       allow(@pg_result).to receive(:values).and_return([[exceedded_wip_limit_results]])
     end
 
-    it "read the notification from the postgres database" do
+    it "read the exceeded wip counts by domain from the postgres database" do
       read = @bot.read
 
       expect(read).to be_a Read::Types::Response
@@ -85,13 +85,13 @@ RSpec.describe Bot::FormatWipLimitExceeded do
       expect(@bot.process(read_response)).to eq({ success: { notification: "" } })
     end
 
-    it "returns an empty success hash when the birthdays list is empty" do
+    it "returns an empty success hash when the exceeded_domain_count hash is empty" do
       read_response = Read::Types::Response.new({ "exceeded_domain_count" => {} })
 
       expect(@bot.process(read_response)).to eq({ success: { notification: "" } })
     end
 
-    it "returns a success hash with the list of formatted birthdays" do
+    it "returns a success hash with the list of formatted exceeded domain count" do
       read_response = Read::Types::Response.new({ "exceeded_domain_count" => exceedded_wip_limit })
       processed = @bot.process(read_response)
 

--- a/spec/v2/bot/format_wip_limit_exceeded_spec.rb
+++ b/spec/v2/bot/format_wip_limit_exceeded_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "v2/bot/format_wip_limit_exceeded"
+
+RSpec.describe Bot::FormatWipLimitExceeded do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "use_cases",
+        bot_name: "CompareWipLimitCount"
+      },
+      process_options: {
+        template: ":warning: The <domain> WIP limit was exceeded by <exceeded>"
+      },
+      write_options: {
+        connection:,
+        db_table: "use_cases",
+        bot_name: "FormatWipLimitExceeded"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(1).arguments }
+    it { expect(@bot).to respond_to(:write).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:exceedded_wip_limit_results) do
+      "{\"exceeded_domain_count\": [{\"domain\": \"engineering\", \"exceeded\": 1}]}"
+    end
+
+    let(:formatted_exceedded_wip_limit) do
+      { "exceeded_domain_count" => [{ "domain" => "engineering", "exceeded" => 1 }] }
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[exceedded_wip_limit_results]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_exceedded_wip_limit)
+    end
+  end
+
+  describe ".process" do
+    let(:exceedded_wip_limit) do
+      [{ "domain" => "engineering", "exceeded" => 1 }]
+    end
+
+    let(:formatted_exceedded_wip_limit) { " :warning: The engineering WIP limit was exceeded by 1 \n" }
+
+    it "returns an empty success hash when the record was not found" do
+      read_response = Read::Types::Response.new(nil)
+
+      expect(@bot.process(read_response)).to eq({ success: { notification: "" } })
+    end
+
+    it "returns an empty success hash when the birthdays list is empty" do
+      read_response = Read::Types::Response.new({ "exceeded_domain_count" => {} })
+
+      expect(@bot.process(read_response)).to eq({ success: { notification: "" } })
+    end
+
+    it "returns a success hash with the list of formatted birthdays" do
+      read_response = Read::Types::Response.new({ "exceeded_domain_count" => exceedded_wip_limit })
+      processed = @bot.process(read_response)
+
+      expect(processed).to eq({ success: { notification: formatted_exceedded_wip_limit } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:formatted_exceedded_wip_limit) { " :warning: The engineering WIP limit was exceeded by 1 \n" }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      process_response = { success: { notification: formatted_exceedded_wip_limit } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #33 

## Context
On this PR, the WIP limit notification use case was refactored. For this: 
- A new BOT was added to fetch the WIP counts by domain from a Notion database.
- A new BOT was added to fetch the WIP limits by domain from a Notion database.
- A new BOT was added to calculate the domains that have exceeded the limit.
- A new BOT was added to format the notification message.

Example of use:
```ruby
connection = {
    host: "localhost",
    port: 5432,
    dbname: "bas",
    user: "postgres",
    password: "postgres"
  }

## FetchDomainsWipCountsFromNotion
  options = {
    process_options: {
      database_id: "notion database id",
      secret: "notion secret"
    },
    write_options: {
      connection:,
      db_table: "use_cases",
      bot_name: "FetchDomainsWipCountsFromNotion"
    }
  }

  Bot::FetchDomainsWipCountsFromNotion.new(options).execute

## FetchDomainsWipLimitFromNotion
  options = {
    read_options: {
      connection:,
      db_table: "use_cases",
      bot_name: "FetchDomainsWipCountsFromNotion"
    },
    process_options: {
      database_id: "notion database id",
      secret: "notion secret"
    },
    write_options: {
      connection:,
      db_table: "use_cases",
      bot_name: "FetchDomainsWipLimitFromNotion"
    }
  }

  Bot::FetchDomainsWipLimitFromNotion.new(options).execute

## CompareWipLimitCount
  options = {
    read_options: {
      connection:,
      db_table: "use_cases",
      bot_name: "FetchDomainsWipLimitFromNotion"
    },
    write_options: {
      connection:,
      db_table: "use_cases",
      bot_name: "CompareWipLimitCount"
    }
  }

  Bot::CompareWipLimitCount.new(options).execute

## FormatWipLimitExceeded
  options = {
    read_options: {
      connection:,
      db_table: "use_cases",
      bot_name: "CompareWipLimitCount"
    },
    process_options: {
      template: ":warning: The <domain> WIP limit was exceeded by <exceeded>"
    },
    write_options: {
      connection:,
      db_table: "use_cases",
      bot_name: "FormatWipLimitExceeded"
    }
  }

  Bot::FormatWipLimitExceeded.new(options).execute

## NotifyDiscord
  options = {
    read_options: {
      connection:,
      db_table: "use_cases",
      bot_name: "FormatWipLimitExceeded"
    },
    process_options: {
      name: "fgsBOT",
      webhook: "discord webhook"
    },
    write_options: {
      connection:,
      db_table: "use_cases",
      bot_name: "NotifyDiscord"
    }
  }

  Bot::NotifyDiscord.new(options).execute
```