### PR TITLE
Solve #34 - Refactor support email Use Case

### DIFF
--- a/lib/v2/bot/fetch_emails_from_imap.rb
+++ b/lib/v2/bot/fetch_emails_from_imap.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/default"
+require_relative "../utils/imap/request"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::FetchEmailsFromImap class serves as a bot implementation to fetch emails from a imap server
+  # and write them on a PostgresDB table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   params = {
+  #     process_options: {
+  #       refresh_token: "email server refresh token",
+  #       client_id: "email server client it",
+  #       client_secret: "email server client secret",
+  #       token_uri: "email server refresh token uri",
+  #       email_domain: "email server domain",
+  #       email_port: "email server port",
+  #       user_email: "email to be access",
+  #       search_email: "email to be search",
+  #       inbox: "inbox to be search"
+  #     },
+  #     write_options: {
+  #       connection:,
+  #       db_table: "use_cases",
+  #       bot_name: "FetchEmailsFromImap"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FetchEmailsFromImap.new(options)
+  #   bot.execute
+  #
+  class FetchEmailsFromImap < Bot::Base
+    # Read function to execute the default Read component
+    #
+    def read
+      reader = Read::Default.new
+
+      reader.execute
+    end
+
+    # Process function to request email from an imap server using the imap utility
+    #
+    def process(_read_response)
+      response = Utils::Imap::Request.new(process_options, query).execute
+
+      if response[:error]
+        { error: response }
+      else
+        emails = normalize_response(response[:emails])
+
+        { success: { emails: } }
+      end
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write(process_response)
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def query
+      yesterday = (Time.now - (60 * 60 * 24)).strftime("%d-%b-%Y")
+
+      ["TO", process_options[:search_email], "SINCE", yesterday]
+    end
+
+    def normalize_response(results)
+      return [] if results.nil?
+
+      results.map do |value|
+        message = value[:message]
+
+        {
+          "message_id": value[:message_id],
+          "sender" => extract_sender(message),
+          "date" => message.date,
+          "subject" => message.subject
+        }
+      end
+    end
+
+    def extract_sender(value)
+      mailbox = value.sender[0]["mailbox"]
+      host = value.sender[0]["host"]
+
+      "#{mailbox}@#{host}"
+    end
+  end
+end

--- a/lib/v2/bot/format_emails.rb
+++ b/lib/v2/bot/format_emails.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::FormatEmails class serves as a bot implementation to read emails from a
+  # PostgresDB database, format them with a specific template, and write them on a PostgresDB
+  # table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases",
+  #       bot_name: "FetchEmailsFromImap"
+  #     },
+  #     process_options: {
+  #       template: "emails template message"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases",
+  #       bot_name: "FormatEmails"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FormatEmails.new(options)
+  #   bot.execute
+  #
+  class FormatEmails < Bot::Base
+    EMAIL_ATTRIBUTES = %w[subject sender date].freeze
+
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options)
+
+      reader.execute
+    end
+
+    # Process function to format the notification using a template
+    #
+    def process(read_response)
+      return { success: { notification: "" } } if read_response.data.nil? || read_response.data["emails"] == []
+
+      emails_list = read_response.data["emails"]
+
+      notification = emails_list.reduce("") do |payload, email|
+        "#{payload} #{build_template(EMAIL_ATTRIBUTES, email)} \n"
+      end
+
+      { success: { notification: } }
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write(process_response)
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def build_template(attributes, instance)
+      template = process_options[:template]
+
+      attributes.reduce(template) do |formated_template, attribute|
+        formated_template.gsub("<#{attribute}>", instance[attribute].to_s)
+      end
+    end
+  end
+end

--- a/lib/v2/utils/imap/request.rb
+++ b/lib/v2/utils/imap/request.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "gmail_xoauth"
+require "httparty"
+
+module Utils
+  module Imap
+    ##
+    # This module is a Imap utility for request emails from a Imap server
+    #
+    class Request
+      def initialize(params, query)
+        @refresh_token = params[:refresh_token]
+        @client_id = params[:client_id]
+        @client_secret = params[:client_secret]
+        @token_uri = params[:token_uri]
+        @email_domain = params[:email_domain]
+        @email_port = params[:email_port]
+        @user_email = params[:user_email]
+        @inbox = params[:inbox]
+        @query = query
+
+        @emails = []
+      end
+
+      # Execute the imap requets after authenticate the email with the credentials
+      #
+      def execute
+        response = refresh_token
+
+        return { error: response } unless response["error"].nil?
+
+        imap_fetch(response["access_token"])
+
+        { emails: @emails }
+      rescue StandardError => e
+        { error: e.to_s }
+      end
+
+      private
+
+      def imap_fetch(access_token)
+        imap = Net::IMAP.new(@email_domain, port: @email_port, ssl: true)
+
+        imap.authenticate("XOAUTH2", @user_email, access_token)
+
+        imap.examine(@inbox)
+
+        @emails = fetch_emails(imap)
+
+        imap.logout
+        imap.disconnect
+      end
+
+      def fetch_emails(imap)
+        imap.search(@query).map do |message_id|
+          { message_id:, message: imap.fetch(message_id, "ENVELOPE")[0].attr["ENVELOPE"] }
+        end
+      end
+
+      def refresh_token
+        HTTParty.post(@token_uri, { body: })
+      end
+
+      def body
+        {
+          "grant_type" => "refresh_token",
+          "refresh_token" => @refresh_token,
+          "client_id" => @client_id,
+          "client_secret" => @client_secret
+        }
+      end
+    end
+  end
+end

--- a/lib/v2/utils/imap/request.rb
+++ b/lib/v2/utils/imap/request.rb
@@ -7,7 +7,7 @@ require "httparty"
 module Utils
   module Imap
     ##
-    # This module is a Imap utility for request emails from a Imap server
+    # This module is a Imap utility for request emails from an Imap server
     #
     class Request
       def initialize(params, query)

--- a/spec/v2/bot/fetch_emails_from_imap_spec.rb
+++ b/spec/v2/bot/fetch_emails_from_imap_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "v2/bot/fetch_emails_from_imap"
+
+RSpec.describe Bot::FetchEmailsFromImap do
+  before do
+    config = {
+      process_options: {
+        refresh_token: "refresh_token",
+        client_id: "client_id",
+        client_secret: "client_secret",
+        token_uri: "token_uri",
+        email_domain: "email_domain",
+        email_port: "email_port",
+        user_email: "user_email",
+        search_email: "search_email",
+        inbox: "inbox"
+      },
+      write_options: {
+        connection: {
+          host: "host",
+          port: 5432,
+          dbname: "bas",
+          user: "postgres",
+          password: "postgres"
+        },
+        db_table: "use_cases",
+        bot_name: "FetchEmailsFromImap"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(1).arguments }
+    it { expect(@bot).to respond_to(:write).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    it { expect(@bot.read).to be_a Read::Types::Response }
+  end
+
+  describe ".process" do
+    let(:response) { double("http_response") }
+    let(:message) do
+      double("message", sender: [{ "mailbox" => "user", "host" => "mail.com" }], date: "10/05/2024", subject: "test")
+    end
+
+    let(:imap) do
+      stub = {
+        authenticate: true,
+        examine: true,
+        logout: true,
+        disconnect: true,
+        search: [1, 2, 3, 4],
+        fetch: [double("email", attr: { "ENVELOPE" => message })]
+      }
+
+      instance_double(Net::IMAP, stub)
+    end
+
+    let(:email) { { :message_id => 1, "sender" => "user@mail.com", "date" => "10/05/2024", "subject" => "test" } }
+
+    before do
+      @read_response = Read::Types::Response.new
+
+      allow(HTTParty).to receive(:post).and_return(response)
+      allow(Net::IMAP).to receive(:new).and_return(imap)
+    end
+
+    it "returns a success hash with list of emails" do
+      allow(response).to receive(:[]).and_return(nil, "ABCDEFG123456")
+
+      processed = @bot.process(@read_response)
+
+      expect(processed[:success][:emails]).to include(email)
+    end
+
+    it "returns an error hash when the access_token can not be requested" do
+      allow(response).to receive(:[]).and_return(true)
+
+      processed = @bot.process(@read_response)
+
+      expect(processed).to eq({ error: { error: response } })
+    end
+
+    it "returns an error hash when the imap request fails" do
+      allow(response).to receive(:[]).and_return(nil)
+      allow(imap).to receive(:search).and_raise(StandardError)
+
+      processed = @bot.process(@read_response)
+
+      expect(processed).to eq({ error: { error: "StandardError" } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:email) { { :message_id => 1, "sender" => "user@mail.com", "date" => "10/05/2024", "subject" => "test" } }
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      process_response = { success: { emails: [email] } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+  end
+end

--- a/spec/v2/bot/format_emails_spec.rb
+++ b/spec/v2/bot/format_emails_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "v2/bot/format_emails"
+
+RSpec.describe Bot::FormatEmails do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "use_cases",
+        bot_name: "FetchEmailsFromImap"
+      },
+      process_options: {
+        template: "The <sender> has requested support the <date>"
+      },
+      write_options: {
+        connection:,
+        db_table: "use_cases",
+        bot_name: "FormatEmails"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(1).arguments }
+    it { expect(@bot).to respond_to(:write).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:emails_results) do
+      "{\"emails\": [{\"date\": \"Thu, 09 May\", \"sender\": \"user@mail.com\"}]}"
+    end
+
+    let(:formatted_emails) do
+      { "emails" => [{ "date" => "Thu, 09 May", "sender" => "user@mail.com" }] }
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[emails_results]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_emails)
+    end
+  end
+
+  describe ".process" do
+    let(:emails) { [{ "date" => "Thu, 09 May", "sender" => "user@mail.com" }] }
+
+    let(:formatted_emails) do
+      " The user@mail.com has requested support the Thu, 09 May \n"
+    end
+
+    it "returns an empty success hash when the birthdays list is empty" do
+      read_response = Read::Types::Response.new({ "emails" => [] })
+
+      expect(@bot.process(read_response)).to eq({ success: { notification: "" } })
+    end
+
+    it "returns an empty success hash when the record was not found" do
+      read_response = Read::Types::Response.new(nil)
+
+      expect(@bot.process(read_response)).to eq({ success: { notification: "" } })
+    end
+
+    it "returns a success hash with the list of formatted birthdays" do
+      read_response = Read::Types::Response.new({ "emails" => emails })
+      processed = @bot.process(read_response)
+
+      expect(processed).to eq({ success: { notification: formatted_emails } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:formatted_emails) do
+      " The user@mail.com has requested support the Thu, 09 May \n"
+    end
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      process_response = { success: { notification: formatted_emails } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+  end
+end

--- a/spec/v2/bot/format_emails_spec.rb
+++ b/spec/v2/bot/format_emails_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Bot::FormatEmails do
     let(:emails) { [{ "date" => "Thu, 09 May", "sender" => "user@mail.com" }] }
 
     let(:formatted_emails) do
-      " The user@mail.com has requested support the Thu, 09 May \n"
+      " The user@mail.com has requested support the 2024-05-09 12:00:00 AM \n"
     end
 
     it "returns an empty success hash when the birthdays list is empty" do


### PR DESCRIPTION
Closes #34 

## Context
On this PR, the support emais notification use case was refactored. For this:
- A new BOT was added to fetch email from an Imap server
- A new BOT was added to format the emails notifications

Example of us:
```ruby
## FetchEmailsFromImap
params = {
  process_options: {
    refresh_token: "email server refresh token",
    client_id: "email server client it",
    client_secret: "email server client secret",
    token_uri: "email server refresh token uri",
    email_domain: "email server domain",
    email_port: "email server port",
    user_email: "email to be access",
    search_email: "email to be search",
    inbox: "inbox to be search"
  },
  write_options: {
    connection:,
    db_table: "use_cases",
    bot_name: "FetchEmailsFromImap"
  }
}

bot = Bot::FetchEmailsFromImap.new(options)
bot.execute

## FormatEmails
options = {
  read_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "use_cases",
    bot_name: "FetchEmailsFromImap"
  },
  process_options: {
    template: "emails template message"
  },
  write_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "use_cases",
    bot_name: "FormatEmails"
  }
}

bot = Bot::FormatEmails.new(options)
bot.execute
```