### PR TITLE
Solve #42 - Add a garbage collector

### DIFF
--- a/lib/v2/bot/fetch_domains_wip_limit_from_notion.rb
+++ b/lib/v2/bot/fetch_domains_wip_limit_from_notion.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "./base"
-require_relative "../read/default"
+require_relative "../read/postgres"
 require_relative "../utils/notion/request"
 require_relative "../write/postgres"
 

--- a/lib/v2/bot/garbage_collector.rb
+++ b/lib/v2/bot/garbage_collector.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/default"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::GarbageCollector class serves as a bot implementation to archive bot records from a
+  # PostgresDB database table and write a response on a PostgresDB table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     process_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "use_cases"
+  #     }
+  #   }
+  #
+  #   bot = Bot::GarbageCollector.new(options)
+  #   bot.execute
+  #
+  class GarbageCollector < Bot::Base
+    SUCCESS_STATUS = "PGRES_COMMAND_OK"
+
+    # Read function to execute the default Read component
+    #
+    def read
+      reader = Read::Default.new
+
+      reader.execute
+    end
+
+    # Process function to update records in a PostgresDB database table
+    #
+    def process(_read_response)
+      response = Utils::Postgres::Request.execute(params)
+
+      if response.res_status == SUCCESS_STATUS
+        { success: { archived: true } }
+      else
+        { error: { message: response.result_error_message, status_code: response.res_status } }
+      end
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write(process_response)
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def params
+      {
+        connection: process_options[:connection],
+        query:
+      }
+    end
+
+    def query
+      "UPDATE #{process_options[:db_table]} SET archived=true WHERE archived=false"
+    end
+  end
+end

--- a/spec/v2/bot/garbage_collector_spec.rb
+++ b/spec/v2/bot/garbage_collector_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "v2/bot/garbage_collector"
+
+RSpec.describe Bot::GarbageCollector do
+  before do
+    connection = {
+      host: "host",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      process_options: {
+        connection:,
+        db_table: "use_cases"
+      },
+      write_options: {
+        connection:,
+        db_table: "use_cases",
+        bot_name: "GarbageCollector"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(1).arguments }
+    it { expect(@bot).to respond_to(:write).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    it { expect(@bot.read).to be_a Read::Types::Response }
+  end
+
+  describe ".process" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:pg_result) { instance_double(PG::Result) }
+
+    before do
+      @read_response = Read::Types::Response.new
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec).and_return(pg_result)
+    end
+
+    it "returns a success hash if the records were updated" do
+      allow(pg_result).to receive(:res_status).and_return("PGRES_COMMAND_OK")
+
+      processed = @bot.process(@read_response)
+
+      expect(processed).to eq({ success: { archived: true } })
+    end
+
+    it "returns an error hash with the error message" do
+      allow(pg_result).to receive(:res_status).and_return("PGRES_BAD_RESPONSE")
+      allow(pg_result).to receive(:result_error_message).and_return("error_message")
+
+      processed = @bot.process(@read_response)
+
+      expect(processed).to eq({ error: { message: "error_message", status_code: "PGRES_BAD_RESPONSE" } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      process_response = { success: { archived: true } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      process_response = { error: { message: "error_message", status_code: "PGRES_BAD_RESPONSE" } }
+
+      expect(@bot.write(process_response)).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #42 

## Context
On this PR, a new BOT was added called GarbageCollector. This BOT archives all the records on a PostgresDB table. Example of use: 
```ruby
options = {
  process_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "use_cases"
  },
  write_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "use_cases"
  }
}

bot = Bot::GarbageCollector.new(options)
bot.execute
```