### PR TITLE
Solve #50 - Media review notion fetch

### DIFF
--- a/lib/bas/bot/fetch_media_from_notion.rb
+++ b/lib/bas/bot/fetch_media_from_notion.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/default"
+require_relative "../utils/notion/request"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::FetchMediaFromNotion class serves as a bot implementation to read media (text or images)
+  # from a notion database and write them on a PostgresDB table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     process_options: {
+  #       database_id: "notion_database_id",
+  #       secret: "notion_secret",
+  #       property: "paragraph"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "review_media",
+  #       tag: "FetchMediaFromNotion"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FetchMediaFromNotion.new(options)
+  #   bot.execute
+  #
+  class FetchMediaFromNotion < Bot::Base
+    CONTENT_STATUS = "review"
+
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Default.new
+
+      reader.execute
+    end
+
+    # Process function to execute the Notion utility to fetch media from a notion database
+    #
+    def process
+      media_response = fetch_media
+
+      return media_response unless media_response[:error].nil?
+
+      { success: media_response[:results] }
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def fetch_media
+      request_ids_response = fetch_requests_ids
+
+      return request_ids_response unless request_ids_response[:error].nil?
+
+      { results: fetch_pages(request_ids_response[:ids]) }
+    end
+
+    def fetch_requests_ids
+      response = Utils::Notion::Request.execute(params_database)
+
+      return error(response) unless response.code == 200
+
+      { ids: response["results"]&.map { |result| result["id"] } }
+    end
+
+    def fetch_pages(pages_ids)
+      pages_ids.map do |page_id|
+        content_response = fetch_content(page_id)
+
+        process_content(page_id, content_response)
+      end
+    end
+
+    def process_content(page_id, content)
+      return content unless content[:error].nil?
+
+      filter_media(page_id, content[:results])
+    end
+
+    def filter_media(page_id, page_content)
+      medias = page_content.select { |content| content["type"] == process_options[:property] }
+
+      media = extract_content(medias)
+      created_by = medias.first["created_by"]["id"] unless medias.first.nil?
+
+      { media:, page_id:, created_by:, property: process_options[:property] }
+    end
+
+    def extract_content(content)
+      case process_options[:property]
+      when "image" then process_images(content)
+      when "paragraph" then process_text(content)
+      end
+    end
+
+    def process_images(images)
+      images.map { |image| image["image"]["file"]["url"] }
+    end
+
+    def process_text(texts)
+      texts.reduce("") do |paragraph, text|
+        rich_text = text["paragraph"]["rich_text"].first
+
+        content = rich_text.nil? ? "" : rich_text["plain_text"]
+
+        paragraph + content
+      end
+    end
+
+    def fetch_content(block_id)
+      response = fetch_block(block_id)
+
+      return error(response) unless response.code == 200
+
+      { results: response["results"] }
+    end
+
+    def error(response)
+      { error: { message: response.parsed_response, status_code: response.code } }
+    end
+
+    def params_database
+      {
+        endpoint: "databases/#{process_options[:database_id]}/query",
+        secret: process_options[:secret],
+        method: "post",
+        body: body_database
+      }
+    end
+
+    def body_database
+      {
+        filter: {
+          property: process_options[:property],
+          select: {
+            equals: CONTENT_STATUS
+          }
+        }
+      }
+    end
+
+    def fetch_block(block_id)
+      params = block_params(block_id)
+
+      Utils::Notion::Request.execute(params)
+    end
+
+    def block_params(block_id)
+      {
+        endpoint: "blocks/#{block_id}/children",
+        secret: process_options[:secret],
+        method: "get",
+        body: {}
+      }
+    end
+  end
+end

--- a/lib/bas/bot/fetch_media_from_notion.rb
+++ b/lib/bas/bot/fetch_media_from_notion.rb
@@ -125,11 +125,11 @@ module Bot
 
     def process_text(texts)
       texts.reduce("") do |paragraph, text|
-        rich_text = text["paragraph"]["rich_text"].first
+        rich_text = text["paragraph"]["rich_text"].map { |plain_text| plain_text["plain_text"] }
 
-        content = rich_text.nil? ? "" : rich_text["plain_text"]
+        content = rich_text.empty? ? "" : rich_text.join(" ")
 
-        paragraph + content
+        "#{paragraph}\n#{content}"
       end
     end
 

--- a/spec/bas/bot/fetch_media_from_notion_spec.rb
+++ b/spec/bas/bot/fetch_media_from_notion_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Bot::FetchMediaFromNotion do
 
       processed = @bot.process
 
-      expect(processed).to eq({ success: [{ created_by: "1234567", media: "simple text",
+      expect(processed).to eq({ success: [{ created_by: "1234567", media: "\nsimple text",
                                             page_id: "review_table_request", property: "paragraph" }] })
     end
 

--- a/spec/bas/bot/fetch_media_from_notion_spec.rb
+++ b/spec/bas/bot/fetch_media_from_notion_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "bas/bot/fetch_media_from_notion"
+
+RSpec.describe Bot::FetchMediaFromNotion do
+  before do
+    config = {
+      process_options: {
+        database_id: "database_id",
+        secret: "secret",
+        property: "paragraph"
+      },
+      write_options: {
+        connection: {
+          host: "host",
+          port: 5432,
+          dbname: "bas",
+          user: "postgres",
+          password: "postgres"
+        },
+        db_table: "use_cases",
+        tag: "FetchMediaFromNotion"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    it { expect(@bot.read).to be_a Read::Types::Response }
+  end
+
+  describe ".process paragraph" do
+    let(:request_page_ids) { [{ "id" => "review_table_request" }] }
+    let(:content_page) do
+      [{ "created_by" => { "id" => "1234567" }, "type" => "paragraph",
+         "paragraph" => { "rich_text" => [{ "plain_text" => "simple text" }] } }]
+    end
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+    let(:response) { double("http_response") }
+
+    before do
+      @bot.read_response = Read::Types::Response.new
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "returns a success hash with the wip's count by domain" do
+      allow(response).to receive(:code).and_return(200)
+      allow(response).to receive(:[]).and_return(request_page_ids, content_page)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: [{ created_by: "1234567", media: "simple text",
+                                            page_id: "review_table_request", property: "paragraph" }] })
+    end
+
+    it "returns an error hash with the error message when request id failed" do
+      allow(response).to receive(:code).and_return(404)
+      allow(response).to receive(:parsed_response).and_return(error_response)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ error: { message: error_response, status_code: 404 } })
+    end
+
+    it "returns an error hash with the error message when request page id failed" do
+      allow(response).to receive(:code).and_return(200, 404)
+      allow(response).to receive(:[]).and_return(request_page_ids)
+      allow(response).to receive(:parsed_response).and_return(error_response)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: [{ error: {
+                                message: { "message" => "not found", "object" => "error",
+                                           "status" => 404 }, status_code: 404
+                              } }] })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      @bot.process_response = { success: [{ "created_by" => "1234567", "media" => "simple text",
+                                            "page_id" => "review_table_request", "property" => "paragraph" }] }
+
+      expect(@bot.write).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      @bot.process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #50 

## Description
On this PR the Media review notion fetch bot was added.

```ruby
options = {
  process_options: {
    database_id: "notion_database_id",
    secret: "notion_secret",
    property: "paragraph"
  },
  write_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "review_media",
    tag: "FetchMediaFromNotion"
  }
}

bot = Bot::FetchMediaFromNotion.new(options)
bot.execute
```

