### PR TITLE
Solve #51 - Media review write on shared storage

### DIFF
--- a/lib/bas/bot/write_media_review_requests.rb
+++ b/lib/bas/bot/write_media_review_requests.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::WriteMediaReviewRequests class serves as a bot implementation to read from a postgres
+  # shared storage a set of review media requests and create single request on the shared storage to
+  # be processed one by one.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "review_media",
+  #       tag: "FetchMediaFromNotion"
+  #     },
+  #     process_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "review_media",
+  #       tag: "ReviewMediaRequest"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "review_media",
+  #       tag: "WriteMediaReviewRequests"
+  #     }
+  #   }
+  #
+  #   bot = Bot::WriteMediaReviewRequests.new(options)
+  #   bot.execute
+  #
+  class WriteMediaReviewRequests < Bot::Base
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options.merge(conditions))
+
+      reader.execute
+    end
+
+    # Process function to execute the Notion utility create single review requests
+    #
+    def process
+      return { success: { created: nil } } if unprocessable_response
+
+      read_response.data.each { |request| create_request(request) }
+
+      { success: { created: true } }
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def conditions
+      {
+        where: "archived=$1 AND tag=$2 AND stage=$3 ORDER BY inserted_at ASC",
+        params: [false, read_options[:tag], "unprocessed"]
+      }
+    end
+
+    def create_request(request)
+      write_data = write_request(request)
+
+      Write::Postgres.new(process_options, write_data).execute
+    end
+
+    def write_request(request)
+      return { error: request } if request["media"].empty? || !request["error"].nil?
+
+      { success: request }
+    end
+  end
+end

--- a/spec/bas/bot/write_media_review_requests_spec.rb
+++ b/spec/bas/bot/write_media_review_requests_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "bas/bot/write_media_review_requests"
+
+RSpec.describe Bot::WriteMediaReviewRequests do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "use_cases",
+        tag: "FetchMediaFromNotion"
+      },
+      process_options: {
+        connection:,
+        db_table: "use_cases",
+        tag: "ReviewMediaRequest"
+      },
+      write_options: {
+        connection:,
+        db_table: "use_cases",
+        tag: "WriteMediaReviewRequests"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:review_request_results) do
+      "[{ \"created_by\": \"1234567\", \"media\": \"simple text\",
+      \"page_id\": \"review_table_request\", \"property\": \"paragraph\" }]"
+    end
+
+    let(:formatted_review_request) do
+      [{ "created_by" => "1234567", "media" => "simple text",
+         "page_id" => "review_table_request", "property" => "paragraph" }]
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[1, review_request_results, "date"]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Array
+      expect(read.data.first).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_review_request)
+    end
+  end
+
+  describe ".process" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:review_request) do
+      [{ "created_by" => "1234567", "media" => "simple text",
+         "page_id" => "review_table_request", "property" => "paragraph" }]
+    end
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "returns an empty success hash when the media list is empty" do
+      @bot.read_response = Read::Types::Response.new(1, { "media" => [] }, "date")
+
+      expect(@bot.process).to eq({ success: { created: nil } })
+    end
+
+    it "returns an empty success hash when the record was not found" do
+      @bot.read_response = Read::Types::Response.new(1, nil, "date")
+
+      expect(@bot.process).to eq({ success: { created: nil } })
+    end
+
+    it "returns a success hash after writting the requests in the shared storage" do
+      @bot.read_response = Read::Types::Response.new(1, review_request, "date")
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { created: true } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      @bot.process_response = { success: { created: true } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #51 

## Description
On this PR the  Media review notion update bot was added.

```ruby
options = {
  read_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "review_media",
    tag: "FetchMediaFromNotion"
  },
  process_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "review_media",
    tag: "ReviewMediaRequest"
  },
  write_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "review_media",
    tag: "WriteMediaReviewRequests"
  }
}

bot = Bot::WriteMediaReviewRequests.new(options)
bot.execute
```

