### PR TITLE
Solve #53 - Media review notion block format

### DIFF
--- a/lib/bas/bot/format_media_review.rb
+++ b/lib/bas/bot/format_media_review.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../write/postgres"
+require_relative "../utils/openai/run_assistant"
+
+module Bot
+  ##
+  # The Bot::FormatMediaReview class serves as a bot implementation to read from a postgres
+  # shared storage reviewed media request and format it to Notion blocks.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "review_media",
+  #       tag: "ReviewText"
+  #     },
+  #     process_options: {
+  #       secret: "openai_secret",
+  #       assistant_id: "openai_assistant_id"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "review_media",
+  #       tag: "FormatMediaReview"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FormatMediaReview.new(options)
+  #   bot.execute
+  #
+  class FormatMediaReview < Bot::Base
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options.merge(conditions))
+
+      reader.execute
+    end
+
+    # process function to execute the OpenaAI utility to format the review request to notion Blocks
+    #
+    def process
+      return { success: { formated_review: nil } } if unprocessable_response
+
+      response = Utils::OpenAI::RunAssitant.execute(params)
+
+      if response.code != 200 || (!response["status"].nil? && response["status"] != "completed")
+        return error_response(response)
+      end
+
+      sucess_response(response)
+    end
+
+    # write function to execute the PostgresDB write component
+    #
+    def write
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def conditions
+      {
+        where: "archived=$1 AND tag=$2 AND stage=$3 ORDER BY inserted_at ASC",
+        params: [false, read_options[:tag], "unprocessed"]
+      }
+    end
+
+    def params
+      {
+        assistant_id: process_options[:assistant_id],
+        secret: process_options[:secret],
+        prompt: read_response.data["review"]
+      }
+    end
+
+    def response_data(response)
+      response.parsed_response["data"].first["content"].first["text"]["value"]
+    end
+
+    def sucess_response(response)
+      review = response_data(response)
+      page_id = read_response.data["page_id"]
+      created_by = read_response.data["created_by"]
+      property = read_response.data["property"]
+      media_type = read_response.data["media_type"]
+
+      { success: { review:, page_id:, created_by:, property:, media_type: } }
+    end
+
+    def error_response(response)
+      { error: { message: response.parsed_response, status_code: response.code } }
+    end
+  end
+end

--- a/spec/bas/bot/format_media_review_spec.rb
+++ b/spec/bas/bot/format_media_review_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "bas/bot/format_media_review"
+
+RSpec.describe Bot::FormatMediaReview do
+  before do
+    connection = {
+      host: "host",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "review_media",
+        tag: "ReviewText"
+      },
+      process_options: {
+        assistant_id: "assistant_id",
+        secret: "secret"
+      },
+      write_options: {
+        connection:,
+        db_table: "review_media",
+        tag: "FormatMediaReview"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:review_request_results) do
+      "{ \"created_by\": \"1234567\", \"review\": \"simple text\",\"page_id\":
+      \"review_table_request\", \"property\": \"paragraph\", \"media_type\": \"paragraph\" }"
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[1, review_request_results, "date"]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+    end
+  end
+
+  describe ".process" do
+    let(:review_request) do
+      { "created_by" => "1234567", "review" => "simple text",
+        "page_id" => "review_table_request", "property" => "paragraph", "media_type" => "paragraph" }
+    end
+
+    let(:run) { double("run", parsed_response: { "id" => "run_id", "thread_id" => "thread_id" }) }
+    let(:pol) { double("pol", parsed_response: { error: { message: "pol run fail" } }) }
+    let(:list) { double("list", parsed_response: { error: { message: "list message fail" } }) }
+    let(:success) { { "data" => [{ "content" => [{ "text" => { "value" => "notification" } }] }] } }
+
+    let(:error_response) { { "code": 50_027, "message": "Invalid Webhook Token" } }
+
+    before do
+      @bot.read_response = Read::Types::Response.new(1, review_request, "date")
+
+      allow(HTTParty).to receive(:post).and_return(run)
+      allow(HTTParty).to receive(:get).and_return(pol, list)
+    end
+
+    it "returns an empty success hash when the review is empty" do
+      @bot.read_response = Read::Types::Response.new(1, {}, "date")
+
+      expect(@bot.process).to eq({ success: { formated_review: nil } })
+    end
+
+    it "returns an empty success hash when the record was not found" do
+      @bot.read_response = Read::Types::Response.new(1, nil, "date")
+
+      expect(@bot.process).to eq({ success: { formated_review: nil } })
+    end
+
+    it "returns an error when the thread and run build fail" do
+      allow(run).to receive(:code).and_return(404)
+      allow(run).to receive(:[]).and_return("completed")
+
+      response = @bot.process
+
+      expect(response).to eq({ error: { message: { "id" => "run_id", "thread_id" => "thread_id" },
+                                        status_code: 404 } })
+    end
+
+    it "returns an error when the pol run fail" do
+      allow(run).to receive(:code).and_return(200)
+      allow(pol).to receive(:[]).and_return("failed")
+      allow(pol).to receive(:code).and_return(401)
+
+      response = @bot.process
+
+      expect(response).to eq({ error: { message: { error: { message: "pol run fail" } },
+                                        status_code: 401 } })
+    end
+
+    it "returns an error when the list messages endpoint fail" do
+      allow(run).to receive(:code).and_return(200)
+      allow(pol).to receive(:[]).and_return("completed")
+      allow(pol).to receive(:code).and_return(200)
+      allow(list).to receive(:code).and_return(500)
+
+      response = @bot.process
+
+      expect(response).to eq({ error: { message: { error: { message: "list message fail" } },
+                                        status_code: 500 } })
+    end
+
+    it "returns an success when the openai assistant returns reponse" do
+      allow(run).to receive(:code).and_return(200)
+      allow(pol).to receive(:[]).and_return("completed")
+      allow(pol).to receive(:code).and_return(200)
+      allow(list).to receive(:code).and_return(200)
+      allow(list).to receive(:[]).and_return("completed")
+      allow(list).to receive(:parsed_response).and_return(success)
+
+      @bot.process
+    end
+  end
+
+  describe ".write" do
+    let(:error_response) { { "code": 50_027, "message": "Invalid Webhook Token" } }
+
+    before do
+      pg_conn = instance_double(PG::Connection)
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      @bot.process_response = { success: {} }
+
+      expect(@bot.write).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      @bot.process_response = { error: { message: error_response, status_code: 401 } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #53 

## Description
On this PR the  Media review notion block format bot was added.

```ruby
options = {
  read_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "review_media",
    tag: "ReviewText"
  },
  process_options: {
    secret: "openai_secret",
    assistant_id: "openai_assistant_id"
  },
  write_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "review_media",
    tag: "FormatMediaReview"
  }
}

bot = Bot::FormatMediaReview.new(options)
bot.execute
```

