### PR TITLE
Solve #54 - Media review notion update

### DIFF
--- a/lib/bas/bot/write_media_review_in_notion.rb
+++ b/lib/bas/bot/write_media_review_in_notion.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "json"
+
+require_relative "./base"
+require_relative "../read/default"
+require_relative "../utils/notion/request"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::WriteMediaReviewInNotion class serves as a bot implementation to read from a postgres
+  # shared storage formated notion blocks and send them to a Notion page
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "review_media",
+  #       tag: "FormatMediaReview"
+  #     },
+  #     process_options: {
+  #       secret: "notion_secret"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "review_media",
+  #       tag: "WriteMediaReviewInNotion"
+  #     }
+  #   }
+  #
+  #   bot = Bot::WriteMediaReviewInNotion.new(options)
+  #   bot.execute
+  #
+  class WriteMediaReviewInNotion < Bot::Base
+    CHUNK_SIZE = "1000"
+
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options.merge(conditions))
+
+      reader.execute
+    end
+
+    # process function to execute the Notion utility to send formated blocks to a page
+    #
+    def process
+      return { success: { review_added: nil } } if unprocessable_response
+
+      response = Utils::Notion::Request.execute(params)
+
+      if response.code == 200
+        { success: { page_id: read_response.data["page_id"], property: read_response.data["property"] } }
+      else
+        { error: { message: response.parsed_response, status_code: response.code } }
+      end
+    end
+
+    # write function to execute the PostgresDB write component
+    #
+    def write
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def conditions
+      {
+        where: "archived=$1 AND tag=$2 AND stage=$3 ORDER BY inserted_at ASC",
+        params: [false, read_options[:tag], "unprocessed"]
+      }
+    end
+
+    def params
+      {
+        endpoint: "blocks/#{read_response.data["page_id"]}/children",
+        secret: process_options[:secret],
+        method: "patch",
+        body:
+      }
+    end
+
+    def body
+      { children: [{ object: "block", type: "toggle", toggle: }] }
+    end
+
+    def toggle
+      {
+        rich_text: [{ type: "text", text: { content: toggle_title } }, mention],
+        children: toggle_childrens
+      }
+    end
+
+    def toggle_childrens
+      childrens = JSON.parse(read_response.data["review"])
+
+      childrens["children"]
+    end
+
+    def mention
+      {
+        type: "mention",
+        mention: {
+          type: "user",
+          user: { id: read_response.data["created_by"] }
+        }
+      }
+    end
+
+    def toggle_title
+      case read_response.data["media_type"]
+      when "image" then "Image review results/"
+      when "paragraph" then "Text review results/"
+      end
+    end
+  end
+end

--- a/spec/bas/bot/write_media_review_in_notion_spec.rb
+++ b/spec/bas/bot/write_media_review_in_notion_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "bas/bot/write_media_review_in_notion"
+
+RSpec.describe Bot::WriteMediaReviewInNotion do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "use_cases",
+        tag: "FormatMediaReview"
+      },
+      process_options: {
+        secret: "secret"
+      },
+      write_options: {
+        connection:,
+        db_table: "use_cases",
+        tag: "WriteMediaReviewInNotion"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:review_request_results) do
+      "{ \"created_by\": \"1234567\", \"review\": \"simple text\",\"page_id\":
+      \"review_table_request\", \"property\": \"paragraph\", \"media_type\": \"paragraph\" }"
+    end
+
+    let(:review_request) do
+      { "created_by" => "1234567", "review" => "simple text",
+        "page_id" => "review_table_request", "property" => "paragraph", "media_type" => "paragraph" }
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[1, review_request_results, "date"]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(review_request)
+    end
+  end
+
+  describe ".process" do
+    let(:review_request) do
+      { "created_by" => "1234567", "review" => "{\"children\": \"simple text\"}",
+        "page_id" => "review_table_request", "property" => "paragraph", "media_type" => "paragraph" }
+    end
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    let(:response) { double("http_response") }
+
+    before do
+      @bot.read_response = Read::Types::Response.new(1, review_request, "date")
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "returns a success hash with page and property to be updated" do
+      allow(response).to receive(:code).and_return(200)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { page_id: review_request["page_id"], property: review_request["property"] } })
+    end
+
+    it "returns an error hash with the error message" do
+      allow(response).to receive(:code).and_return(404)
+      allow(response).to receive(:parsed_response).and_return(error_response)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ error: { message: error_response, status_code: 404 } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:review_request) do
+      { "created_by" => "1234567", "review" => "{\"children\": \"simple text\"}",
+        "page_id" => "review_table_request", "property" => "paragraph", "media_type" => "paragraph" }
+    end
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      @bot.process_response = { success: review_request }
+
+      expect(@bot.write).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      @bot.process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #54

## Description
On this PR the  Write media review on notion bot was added.

```ruby
options = {
  read_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "review_media",
    tag: "FormatMediaReview"
  },
  process_options: {
    secret: "notion_secret"
  },
  write_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "review_media",
    tag: "WriteMediaReviewInNotion"
  }
}

bot = Bot::WriteMediaReviewInNotion.new(options)
bot.execute
```

