### PR TITLE
Solve #55 - Media review notion status update

### DIFF
--- a/lib/bas/bot/update_review_media_state.rb
+++ b/lib/bas/bot/update_review_media_state.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/default"
+require_relative "../utils/notion/request"
+require_relative "../write/postgres"
+
+module Bot
+  ##
+  # The Bot::UpdateReviewMediaStatus class serves as a bot implementation to read from a postgres
+  # shared storage updated status and update a parameter on a Notion database.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "review_media",
+  #       tag: "WriteMediaReviewInNotion"
+  #     },
+  #     process_options: {
+  #       secret: "notion_secret"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "review_media",
+  #       tag: "UpdateReviewMediaStatus"
+  #     }
+  #   }
+  #
+  #   bot = Bot::UpdateReviewMediaStatus.new(options)
+  #   bot.execute
+  #
+  class UpdateReviewMediaStatus < Bot::Base
+    READY_STATE = "ready"
+
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options.merge(conditions))
+
+      reader.execute
+    end
+
+    # process function to execute the Notion utility to update a Notion database property
+    #
+    def process
+      return { success: { status_updated: nil } } if unprocessable_response
+
+      response = Utils::Notion::Request.execute(params)
+
+      if response.code == 200
+        { success: { status_updated: true } }
+      else
+        { error: { message: response.parsed_response, status_code: response.code } }
+      end
+    end
+
+    # write function to execute the PostgresDB write component
+    #
+    def write
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def conditions
+      {
+        where: "archived=$1 AND tag=$2 AND stage=$3 ORDER BY inserted_at ASC",
+        params: [false, read_options[:tag], "unprocessed"]
+      }
+    end
+
+    def params
+      {
+        endpoint: "pages/#{read_response.data["page_id"]}",
+        secret: process_options[:secret],
+        method: "patch",
+        body:
+      }
+    end
+
+    def body
+      { properties: { read_response.data["property"] => { select: { name: READY_STATE } } } }
+    end
+  end
+end

--- a/spec/bas/bot/update_review_media_state_spec.rb
+++ b/spec/bas/bot/update_review_media_state_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "bas/bot/update_review_media_state"
+
+RSpec.describe Bot::UpdateReviewMediaStatus do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "use_cases",
+        tag: "WriteMediaReviewInNotion"
+      },
+      process_options: {
+        secret: "secret"
+      },
+      write_options: {
+        connection:,
+        db_table: "use_cases",
+        tag: "UpdateReviewMediaStatus"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:review_request_results) do
+      "{ \"page_id\": \"review_table_request\", \"property\": \"paragraph\" }"
+    end
+
+    let(:review_request) do
+      { "page_id" => "review_table_request", "property" => "paragraph" }
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[1, review_request_results, "date"]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(review_request)
+    end
+  end
+
+  describe ".process" do
+    let(:review_request) do
+      { "page_id" => "review_table_request", "property" => "paragraph" }
+    end
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    let(:response) { double("http_response") }
+
+    before do
+      @bot.read_response = Read::Types::Response.new(1, review_request, "date")
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "returns a success hash with page and property to be updated" do
+      allow(response).to receive(:code).and_return(200)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { status_updated: true } })
+    end
+
+    it "returns an error hash with the error message" do
+      allow(response).to receive(:code).and_return(404)
+      allow(response).to receive(:parsed_response).and_return(error_response)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ error: { message: error_response, status_code: 404 } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      @bot.process_response = { success: { status_updated: true } }
+
+      expect(@bot.write).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      @bot.process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #55

## Description
On this PR the update media review status on notion bot was added.

```ruby
options = {
  read_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "review_media",
    tag: "WriteMediaReviewInNotion"
  },
  process_options: {
    secret: "notion_secret"
  },
  write_options: {
    connection: {
      host: "localhost",
      port: 5432,
      dbname: "bas",
      user: "postgres",
      password: "postgres"
    },
    db_table: "review_media",
    tag: "UpdateReviewMediaStatus"
  }
}

bot = Bot::UpdateReviewMediaStatus.new(options)
bot.execute
```

