### PR TITLE
Fix format for error responses

### DIFF
--- a/lib/bas/bot/base.rb
+++ b/lib/bas/bot/base.rb
@@ -50,7 +50,7 @@ module Bot
     def unprocessable_response
       read_data = read_response.data
 
-      read_data.nil? || read_data == {} || read_data.any? { |_key, value| [[], ""].include?(value) }
+      read_data.nil? || read_data == {} || read_data.any? { |_key, value| [[], "", nil].include?(value) }
     end
 
     private

--- a/lib/bas/bot/fetch_media_from_notion.rb
+++ b/lib/bas/bot/fetch_media_from_notion.rb
@@ -53,7 +53,7 @@ module Bot
 
       return media_response unless media_response[:error].nil?
 
-      { success: media_response[:results] }
+      { success: media_response }
     end
 
     # Write function to execute the PostgresDB write component

--- a/lib/bas/bot/review_media.rb
+++ b/lib/bas/bot/review_media.rb
@@ -10,7 +10,7 @@ require_relative "../utils/openai/run_assistant"
 
 module Bot
   ##
-  # The Bot::WriteMediaReviewRequests class serves as a bot implementation to read from a postgres
+  # The Bot::ReviewMedia class serves as a bot implementation to read from a postgres
   # shared storage a set of review media requests and create single request on the shared storage to
   # be processed one by one.
   #

--- a/lib/bas/bot/update_review_media_state.rb
+++ b/lib/bas/bot/update_review_media_state.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "./base"
-require_relative "../read/default"
+require_relative "../read/postgres"
 require_relative "../utils/notion/request"
 require_relative "../write/postgres"
 

--- a/lib/bas/bot/write_media_review_in_notion.rb
+++ b/lib/bas/bot/write_media_review_in_notion.rb
@@ -3,7 +3,7 @@
 require "json"
 
 require_relative "./base"
-require_relative "../read/default"
+require_relative "../read/postgres"
 require_relative "../utils/notion/request"
 require_relative "../write/postgres"
 

--- a/lib/bas/bot/write_media_review_requests.rb
+++ b/lib/bas/bot/write_media_review_requests.rb
@@ -66,7 +66,7 @@ module Bot
     def process
       return { success: { created: nil } } if unprocessable_response
 
-      read_response.data.each { |request| create_request(request) }
+      read_response.data["results"].each { |request| create_request(request) }
 
       { success: { created: true } }
     end

--- a/spec/bas/bot/fetch_media_from_notion_spec.rb
+++ b/spec/bas/bot/fetch_media_from_notion_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe Bot::FetchMediaFromNotion do
 
       processed = @bot.process
 
-      expect(processed).to eq({ success: [{ created_by: "1234567", media: "\nsimple text",
-                                            page_id: "review_table_request", property: "paragraph" }] })
+      expect(processed).to eq({ success: { results: [{ created_by: "1234567", media: "\nsimple text",
+                                                       page_id: "review_table_request", property: "paragraph" }] } })
     end
 
     it "returns an error hash with the error message when request id failed" do
@@ -112,10 +112,10 @@ RSpec.describe Bot::FetchMediaFromNotion do
 
       processed = @bot.process
 
-      expect(processed).to eq({ success: [{ error: {
+      expect(processed).to eq({ success: { results: [{ error: {
                                 message: { "message" => "not found", "object" => "error",
                                            "status" => 404 }, status_code: 404
-                              } }] })
+                              } }] } })
     end
   end
 

--- a/spec/bas/bot/write_media_review_requests_spec.rb
+++ b/spec/bas/bot/write_media_review_requests_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe Bot::WriteMediaReviewRequests do
     let(:pg_conn) { instance_double(PG::Connection) }
 
     let(:review_request) do
-      [{ "created_by" => "1234567", "media" => "simple text",
-         "page_id" => "review_table_request", "property" => "paragraph" }]
+      { "results" => [{ "created_by" => "1234567", "media" => "simple text", "page_id" => "review_table_request",
+                        "property" => "paragraph" }] }
     end
 
     before do


### PR DESCRIPTION
## Description
On this PR, the format for the error media review bots responses was updated to accept nil as a response, and formating the array from the fetch bot to a hash object. 