### PR TITLE
Solve #76 - Update write media request to set in process

### DIFF
--- a/lib/bas/utils/notion/update_db_state.rb
+++ b/lib/bas/utils/notion/update_db_state.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "httparty"
+require_relative "request"
+
+module Utils
+  module Notion
+    ##
+    # This module is a Notion utility for sending update status to notion databases.
+    #
+    module UpdateDbState
+      # Implements the request process logic to Notion.
+      #
+      # <br>
+      # <b>Params:</b>
+      # * <tt>property</tt> Name of the db property to be updated.
+      # * <tt>page_id</tt> Id of the page to be updated.
+      # * <tt>state</tt> State to be updated
+      # * <tt>secret</tt> Notion secret.
+      #
+      # <br>
+      # <b>returns</b> <tt>HTTParty::Response</tt>
+      #
+
+      def self.execute(data)
+        params = build_params(data)
+
+        Utils::Notion::Request.execute(params)
+      end
+
+      def self.build_params(data)
+        {
+          endpoint: "pages/#{data[:page_id]}",
+          secret: data[:secret],
+          method: "patch",
+          body: body(data)
+        }
+      end
+
+      def self.body(data)
+        { properties: { data[:property] => { select: { name: data[:state] } } } }
+      end
+    end
+  end
+end

--- a/spec/bas/bot/write_media_review_requests_spec.rb
+++ b/spec/bas/bot/write_media_review_requests_spec.rb
@@ -85,11 +85,17 @@ RSpec.describe Bot::WriteMediaReviewRequests do
                         "property" => "paragraph" }] }
     end
 
+    let(:response) { double("http_response") }
+
     before do
       pg_result = instance_double(PG::Result)
 
       allow(PG::Connection).to receive(:new).and_return(pg_conn)
       allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+
+      @bot.read_response = Read::Types::Response.new
+
+      allow(HTTParty).to receive(:send).and_return(response)
     end
 
     it "returns an empty success hash when the media list is empty" do

--- a/spec/bas/utils/notion/update_db_state_spec.rb
+++ b/spec/bas/utils/notion/update_db_state_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "bas/utils/notion/update_db_state"
+
+RSpec.describe Utils::Notion::UpdateDbState do
+  before do
+    @data = {
+      property: "text",
+      page_id: "abcd1234",
+      state: "in process",
+      secret: "notion_secret"
+    }
+  end
+
+  describe ".execute" do
+    let(:response) { double("http_response") }
+    before { allow(HTTParty).to receive(:send).and_return(response) }
+
+    it { expect(described_class.execute(@data)).to_not be_nil }
+  end
+
+  describe ".build_params" do
+    it {
+      expect(described_class.build_params(@data)).to eq({
+                                                          endpoint: "pages/abcd1234",
+                                                          secret: "notion_secret",
+                                                          method: "patch", body: {
+                                                            properties: { "text" => { select: { name: "in process" } } }
+                                                          }
+                                                        })
+    }
+  end
+
+  describe ".body" do
+    it {
+      expect(described_class.body(@data)).to eq({ properties: { "text" => { select: { name: "in process" } } } })
+    }
+  end
+end


### PR DESCRIPTION
Solve #76 

## Description
On this PR, a notion utility was added to update the state of a database on notion. Also, the utility was used for the write media review request and the write media review in notion bots to update the request state.