### PR TITLE
Improve digital ocean notification message readability

### DIFF
--- a/lib/bas/bot/format_do_bill_alert.rb
+++ b/lib/bas/bot/format_do_bill_alert.rb
@@ -93,10 +93,10 @@ module Bot
       balance = read_response.data["billing"]["month_to_date_balance"]
       threshold = process_options[:threshold]
 
-      """The daily usage was exceeded.
+      """:warning: The **DigitalOcean** daily usage was exceeded.
       Current balance: #{balance}
       Threshold: #{threshold}
-      Expected daily usage: #{daily_usage.round(3)}
+      Current daily usage: #{daily_usage.round(3)}
       """
     end
   end

--- a/spec/bas/bot/format_do_bill_alert_spec.rb
+++ b/spec/bas/bot/format_do_bill_alert_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Bot::FormatDoBillAlert do
     end
 
     let(:formatted_alert) do
-      "The daily usage was exceeded.\n      Current balance: 800\n      Threshold: 7\n      Expected daily usage: 66.667\n      " # rubocop:disable Layout/LineLength
+      ":warning: The **DigitalOcean** daily usage was exceeded.\n      Current balance: 800\n      Threshold: 7\n      Current daily usage: 50.0\n      " # rubocop:disable Layout/LineLength
     end
 
     it "returns an empty success hash when the billing list is empty" do
@@ -111,7 +111,7 @@ RSpec.describe Bot::FormatDoBillAlert do
     let(:pg_conn) { instance_double(PG::Connection) }
 
     let(:formatted_alert) do
-      "The daily usage was exceeded.\n      Current balance: 800\n      Threshold: 7\n      Expected daily usage: 66.667\n      " # rubocop:disable Layout/LineLength
+      ":warning: The **DigitalOcean** daily usage was exceeded.\n      Current balance: 800\n      Threshold: 7\n      Current daily usage: 50.0\n      " # rubocop:disable Layout/LineLength
     end
 
     before do


### PR DESCRIPTION
## Description
On this PR, the message sent from the FormatDoBillAlert bot was updated to improve readability.

### Example:
![image](https://github.com/user-attachments/assets/498c270a-50e9-4e94-8675-8298d6cf51db)
