### PR TITLE
Solve #83 - Add bots to check webs availability

### DIFF
--- a/lib/bas/bot/fetch_domain_services_from_notion.rb
+++ b/lib/bas/bot/fetch_domain_services_from_notion.rb
@@ -8,7 +8,7 @@ require_relative "../write/postgres"
 module Bot
   ##
   # The Bot::FetchDomainServicesFromNotion class serves as a bot implementation to read
-  # domains from a notion database and write them on a PostgresDB table with a specific format.
+  # web domains from a notion database and write them on a PostgresDB table with a specific format.
   #
   # <br>
   # <b>Example</b>
@@ -41,7 +41,7 @@ module Bot
       reader.execute
     end
 
-    # Process function to execute the Notion utility to fetch domains from a notion database
+    # Process function to execute the Notion utility to fetch web domains from a notion database
     #
     def process
       response = Utils::Notion::Request.execute(params)

--- a/lib/bas/bot/fetch_domain_services_from_notion.rb
+++ b/lib/bas/bot/fetch_domain_services_from_notion.rb
@@ -6,6 +6,34 @@ require_relative "../utils/notion/request"
 require_relative "../write/postgres"
 
 module Bot
+  ##
+  # The Bot::FetchDomainServicesFromNotion class serves as a bot implementation to read
+  # domains from a notion database and write them on a PostgresDB table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     process_options: {
+  #       database_id: "notion database id",
+  #       secret: "notion secret"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "web_availability",
+  #       tag: "FetchDomainServicesFromNotion"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FetchDomainServicesFromNotion.new(options)
+  #   bot.execute
+  #
   class FetchDomainServicesFromNotion < Bot::Base
     def read
       reader = Read::Default.new
@@ -13,7 +41,7 @@ module Bot
       reader.execute
     end
 
-    # Process function to execute the Notion utility to fetch media from a notion database
+    # Process function to execute the Notion utility to fetch domains from a notion database
     #
     def process
       response = Utils::Notion::Request.execute(params)

--- a/lib/bas/bot/fetch_domain_services_from_notion.rb
+++ b/lib/bas/bot/fetch_domain_services_from_notion.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/default"
+require_relative "../utils/notion/request"
+require_relative "../write/postgres"
+
+module Bot
+  class FetchDomainServicesFromNotion < Bot::Base
+    def read
+      reader = Read::Default.new
+
+      reader.execute
+    end
+
+    # Process function to execute the Notion utility to fetch media from a notion database
+    #
+    def process
+      response = Utils::Notion::Request.execute(params)
+
+      if response.code == 200
+        urls_list = normalize_response(response.parsed_response["results"])
+
+        { success: { urls: urls_list } }
+      else
+        { error: { message: response.parsed_response, status_code: response.code } }
+      end
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def params
+      {
+        endpoint: "databases/#{process_options[:database_id]}/query",
+        secret: process_options[:secret],
+        method: "post",
+        body: {}
+      }
+    end
+
+    def normalize_response(results)
+      return [] if results.nil?
+
+      results.map do |value|
+        properties = value["properties"]
+
+        {
+          "url" => extract_rich_text_field_value(properties["domain"])
+        }
+      end
+    end
+
+    def extract_rich_text_field_value(data)
+      data["rich_text"][0]["plain_text"]
+    end
+  end
+end

--- a/lib/bas/bot/review_domain_availability.rb
+++ b/lib/bas/bot/review_domain_availability.rb
@@ -8,6 +8,41 @@ require_relative "../write/postgres"
 require_relative "../utils/openai/run_assistant"
 
 module Bot
+  ##
+  # The Bot::ReviewDomainAvailability class serves as a bot implementation to read from a postgres
+  # shared storage a domain requests and review its availability.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "web_availability",
+  #       tag: "ReviewDomainRequest"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "web_availability",
+  #       tag: "ReviewDomainAvailability"
+  #     }
+  #   }
+  #
+  #   bot = Bot::ReviewDomainAvailability.new(options)
+  #   bot.execute
+  #
   class ReviewDomainAvailability < Bot::Base
     # read function to execute the PostgresDB Read component
     #
@@ -17,7 +52,7 @@ module Bot
       reader.execute
     end
 
-    # process function to execute the OpenaAI utility to process the media reviews
+    # process function to make a http request to the domain and check the status
     #
     def process
       return { success: { review: nil } } if unprocessable_response

--- a/lib/bas/bot/write_domain_review_requests.rb
+++ b/lib/bas/bot/write_domain_review_requests.rb
@@ -6,6 +6,53 @@ require_relative "../utils/notion/update_db_state"
 require_relative "../write/postgres"
 
 module Bot
+  ##
+  # The Bot::WriteDomainReviewRequests class serves as a bot implementation to read from a postgres
+  # shared storage a set of review domain requests and create single request on the shared storage to
+  # be processed one by one.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "web_availability",
+  #       tag: "FetchDomainServicesFromNotion"
+  #     },
+  #     process_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "web_availability",
+  #       tag: "ReviewDomainRequest"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "web_availability",
+  #       tag: "WriteDomainReviewRequests"
+  #     }
+  #   }
+  #
+  #   bot = Bot::WriteDomainReviewRequests.new(options)
+  #   bot.execute
+  #
   class WriteDomainReviewRequests < Bot::Base
     # read function to execute the PostgresDB Read component
     #

--- a/lib/bas/bot/write_domain_review_requests.rb
+++ b/lib/bas/bot/write_domain_review_requests.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../utils/notion/update_db_state"
+require_relative "../write/postgres"
+
+module Bot
+  class WriteDomainReviewRequests < Bot::Base
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options.merge(conditions))
+
+      reader.execute
+    end
+
+    # Process function to execute the Notion utility create single review requests
+    #
+    def process
+      return { success: { created: nil } } if unprocessable_response
+
+      read_response.data["urls"].each { |request| create_request(request) }
+
+      { success: { created: true } }
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def conditions
+      {
+        where: "archived=$1 AND tag=$2 AND stage=$3 ORDER BY inserted_at ASC",
+        params: [false, read_options[:tag], "unprocessed"]
+      }
+    end
+
+    def create_request(request)
+      write_data = write_request(request)
+
+      Write::Postgres.new(process_options, write_data).execute
+    end
+
+    def write_request(request)
+      return { error: request } if request["url"].empty? || !request["error"].nil?
+
+      { success: request }
+    end
+  end
+end

--- a/lib/bas/utils/notion/request.rb
+++ b/lib/bas/utils/notion/request.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "httparty"
+require "json"
 
 module Utils
   module Notion

--- a/spec/bas/bot/fetch_domain_services_from_notion_spec.rb
+++ b/spec/bas/bot/fetch_domain_services_from_notion_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "bas/bot/fetch_domain_services_from_notion"
+
+RSpec.describe Bot::FetchDomainServicesFromNotion do
+  before do
+    config = {
+      process_options: {
+        database_id: "database_id",
+        secret: "secret"
+      },
+      write_options: {
+        connection: {
+          host: "host",
+          port: 5432,
+          dbname: "bas",
+          user: "postgres",
+          password: "postgres"
+        },
+        db_table: "pto",
+        tag: "FetchDomainServicesFromNotion"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    it { expect(@bot.read).to be_a Read::Types::Response }
+  end
+
+  describe ".process" do
+    let(:domains) do
+      {
+        "properties" => {
+          "domain" => { "rich_text" => [{ "plain_text" => "https://domain.com" }] }
+        }
+      }
+    end
+
+    let(:formatted_domains) { { "url" => "https://domain.com" } }
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    let(:response) { double("http_response") }
+
+    before do
+      @bot.read_response = Read::Types::Response.new
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "returns a success hash with the list of formatted ptos" do
+      allow(response).to receive(:code).and_return(200)
+      allow(response).to receive(:parsed_response).and_return({ "results" => [domains] })
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { urls: [formatted_domains] } })
+    end
+
+    it "returns an error hash with the error message" do
+      allow(response).to receive(:code).and_return(404)
+      allow(response).to receive(:parsed_response).and_return(error_response)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ error: { message: error_response, status_code: 404 } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:formatted_domains) { { "url" => "https://domain.com" } }
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      @bot.process_response = { success: { ptos: [formatted_domains] } }
+
+      expect(@bot.write).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      @bot.process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end

--- a/spec/bas/bot/fetch_domain_services_from_notion_spec.rb
+++ b/spec/bas/bot/fetch_domain_services_from_notion_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Bot::FetchDomainServicesFromNotion do
       allow(HTTParty).to receive(:send).and_return(response)
     end
 
-    it "returns a success hash with the list of formatted ptos" do
+    it "returns a success hash with the list of domains to review" do
       allow(response).to receive(:code).and_return(200)
       allow(response).to receive(:parsed_response).and_return({ "results" => [domains] })
 

--- a/spec/bas/bot/format_do_bill_alert_spec.rb
+++ b/spec/bas/bot/format_do_bill_alert_spec.rb
@@ -84,7 +84,9 @@ RSpec.describe Bot::FormatDoBillAlert do
     end
 
     let(:formatted_alert) do
-      ":warning: The **DigitalOcean** daily usage was exceeded.\n      Current balance: 800\n      Threshold: 7\n      Current daily usage: 50.0\n      " # rubocop:disable Layout/LineLength
+      daily_usage = 800.0 / Time.now.utc.mday
+
+      ":warning: The **DigitalOcean** daily usage was exceeded.\n      Current balance: 800\n      Threshold: 7\n      Current daily usage: #{daily_usage.round(3)}\n      " # rubocop:disable Layout/LineLength
     end
 
     it "returns an empty success hash when the billing list is empty" do

--- a/spec/bas/bot/write_domain_review_requests_spec.rb
+++ b/spec/bas/bot/write_domain_review_requests_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "bas/bot/write_domain_review_requests"
+
+RSpec.describe Bot::WriteDomainReviewRequests do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "use_cases",
+        tag: "FetchDomainServicesFromNotion"
+      },
+      process_options: {
+        connection:,
+        db_table: "use_cases",
+        tag: "ReviewDomainRequest"
+      },
+      write_options: {
+        connection:,
+        db_table: "use_cases",
+        tag: "WriteDomainReviewRequests"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:review_request_results) { "[{ \"url\": \"https://domain.com\"}]" }
+
+    let(:formatted_review_request) { [{ "url" => "https://domain.com" }] }
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[1, review_request_results, "date"]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Array
+      expect(read.data.first).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_review_request)
+    end
+  end
+
+  describe ".process" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:review_request) { { "urls" => [{ "url" => "https://domain.com" }] } }
+
+    let(:response) { double("http_response") }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+
+      @bot.read_response = Read::Types::Response.new
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "returns an empty success hash when the domains list is empty" do
+      @bot.read_response = Read::Types::Response.new(1, { "media" => [] }, "date")
+
+      expect(@bot.process).to eq({ success: { created: nil } })
+    end
+
+    it "returns an empty success hash when the record was not found" do
+      @bot.read_response = Read::Types::Response.new(1, nil, "date")
+
+      expect(@bot.process).to eq({ success: { created: nil } })
+    end
+
+    it "returns a success hash after writting the requests in the shared storage" do
+      @bot.read_response = Read::Types::Response.new(1, review_request, "date")
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { created: true } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      @bot.process_response = { success: { created: true } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Description
On this PR, the bots for the check website availability were added. For this:
- FetchDomainServicesFromNotion bot added.
- WriteDomainReviewRequests bot added
- ReviewDomainAvailability bot added

Closes #83 

### Example of use
```ruby
connection = {
  host: "localhost",
  port: 5432,
  dbname: "bas",
  user: "postgres",
  password: "postgres"
}

# # FETCH DOMAINS
options = {
  process_options: {
    database_id: "notion database id",
    secret: "notion secret"
  },
  write_options: {
    connection:,
    db_table: "web_availability",
    tag: "FetchDomainServicesFromNotion"
  }
}

bot = Bot::FetchDomainServicesFromNotion.new(options)
bot.execute

# # WRITE DOMAIN REVIEW REQUESTS
options = {
  read_options: {
    connection:,
    db_table: "web_availability",
    tag: "FetchDomainServicesFromNotion"
  },
  process_options: {
    connection:,
    db_table: "web_availability",
    tag: "ReviewDomainRequest"
  },
  write_options: {
    connection:,
    db_table: "web_availability",
    tag: "WriteDomainReviewRequests"
  }
}

bot = Bot::WriteDomainReviewRequests.new(options)
bot.execute

# # REVIEW: DOMAIN AVAILABILITY

options = {
  read_options: {
    connection:,
    db_table: "web_availability",
    tag: "ReviewDomainRequest"
  },
  write_options: {
    connection:,
    db_table: "web_availability",
    tag: "ReviewDomainAvailability"
  }
}

bot = Bot::ReviewDomainAvailability.new(options)
bot.execute
```