### PR TITLE
Solve #87 - Add bots to synchronize issues with notion work items

### DIFF
--- a/lib/bas/bot/create_work_item.rb
+++ b/lib/bas/bot/create_work_item.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "json"
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../utils/notion/request"
+require_relative "../utils/notion/types"
+require_relative "../write/postgres"
+
+module Bot
+  class CreateWorkItem < Bot::Base
+    include Utils::Notion::Types
+
+    UPDATE_REQUEST = "UpdateWorkItemRequest"
+
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options.merge(conditions))
+
+      reader.execute
+    end
+
+    # process function to execute the Notion utility to send formated blocks to a page
+    #
+    def process
+      return { success: { created: nil } } if unprocessable_response
+
+      response = Utils::Notion::Request.execute(params)
+
+      if response.code == 200
+        { success: { issue: read_response.data["issue"], notion_wi: response["id"] } }
+      else
+        { error: { message: response.parsed_response, status_code: response.code } }
+      end
+    end
+
+    # write function to execute the PostgresDB write component
+    #
+    def write
+      options = write_options.merge({ tag: UPDATE_REQUEST })
+
+      write = Write::Postgres.new(options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def conditions
+      {
+        where: "archived=$1 AND tag=$2 AND stage=$3 ORDER BY inserted_at ASC",
+        params: [false, read_options[:tag], "unprocessed"]
+      }
+    end
+
+    def params
+      {
+        endpoint: "pages",
+        secret: process_options[:secret],
+        method: "post",
+        body:
+      }
+    end
+
+    def body
+      {
+        parent: { database_id: process_options[:database_id] },
+        properties:
+      }
+    end
+
+    def properties
+      {
+        "Responsible domain": select(process_options[:domain]),
+        "Github Issue id": rich_text(read_response.data["issue"]["id"].to_s),
+        "Status": status(process_options[:status]),
+        "Detail": title(read_response.data["issue"]["title"])
+      }.merge(work_item_type)
+    end
+
+    def work_item_type
+      case process_options[:work_item_type]
+      when "activity" then { "Activity": relation(process_options[:activity]) }
+      when "project" then { "Project": relation(process_options[:project]) }
+      else {}
+      end
+    end
+  end
+end

--- a/lib/bas/bot/create_work_item.rb
+++ b/lib/bas/bot/create_work_item.rb
@@ -9,6 +9,49 @@ require_relative "../utils/notion/types"
 require_relative "../write/postgres"
 
 module Bot
+  ##
+  # The Bot::CreateWorkItem class serves as a bot implementation to create "work items" on a
+  # notion database using information of a GitHub issue.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "github_issues",
+  #       tag: "CreateWorkItemRequest"
+  #     },
+  #     process_options: {
+  #       database_id: "notion database id",
+  #       secret: "notion secret",
+  #       domain: "domain association",
+  #       status: "default status",
+  #       work_item_type: "work_item_type",
+  #       project: "project id"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "github_issues",
+  #       tag: "CreateWorkItem"
+  #     }
+  #   }
+  #
+  #   bot = Bot::VerifyIssueExistanceInNotion.new(options)
+  #   bot.execute
+  #
   class CreateWorkItem < Bot::Base
     include Utils::Notion::Types
 
@@ -22,7 +65,8 @@ module Bot
       reader.execute
     end
 
-    # process function to execute the Notion utility to send formated blocks to a page
+    # process function to execute the Notion utility to create work items on a notion
+    # database
     #
     def process
       return { success: { created: nil } } if unprocessable_response

--- a/lib/bas/bot/create_work_item.rb
+++ b/lib/bas/bot/create_work_item.rb
@@ -39,7 +39,7 @@ module Bot
     # write function to execute the PostgresDB write component
     #
     def write
-      options = write_options.merge({ tag: UPDATE_REQUEST })
+      options = write_options.merge({ tag: })
 
       write = Write::Postgres.new(options, process_response)
 
@@ -86,6 +86,12 @@ module Bot
       when "project" then { "Project": relation(process_options[:project]) }
       else {}
       end
+    end
+
+    def tag
+      return write_options[:tag] if process_response[:success][:notion_wi].nil?
+
+      UPDATE_REQUEST
     end
   end
 end

--- a/lib/bas/bot/create_work_item.rb
+++ b/lib/bas/bot/create_work_item.rb
@@ -115,7 +115,7 @@ module Bot
       }
     end
 
-    def properties
+    def properties # rubocop:disable Metrics/AbcSize
       {
         "Responsible domain": select(process_options[:domain]),
         "Github Issue id": rich_text(read_response.data["issue"]["id"].to_s),
@@ -133,7 +133,7 @@ module Bot
     end
 
     def tag
-      return write_options[:tag] if process_response[:success][:notion_wi].nil?
+      return write_options[:tag] if process_response[:success].nil? || process_response[:success][:notion_wi].nil?
 
       UPDATE_REQUEST
     end

--- a/lib/bas/bot/fetch_github_issues.rb
+++ b/lib/bas/bot/fetch_github_issues.rb
@@ -6,6 +6,49 @@ require_relative "../utils/github/octokit_client"
 require_relative "../write/postgres"
 
 module Bot
+  ##
+  # The Bot::FetchGithubIssues class serves as a bot implementation to fetch GitHub issues from a
+  # repository and write them on a PostgresDB table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "github_issues",
+  #       tag: "FetchGithubIssues",
+  #       avoid_process: true
+  #     },
+  #     process_options: {
+  #       private_pem: "Github App private token",
+  #       app_id: "Github App id",
+  #       repo: "repository name",
+  #       filters: "hash with filters",
+  #       organization: "GitHub organization name"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "github_issues",
+  #       tag: "FetchGithubIssues"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FetchGithubIssues.new(options)
+  #   bot.execute
+  #
   class FetchGithubIssues < Bot::Base
     ISSUE_PARAMS = %i[id html_url title body labels state created_at updated_at].freeze
     PER_PAGE = 100
@@ -18,7 +61,7 @@ module Bot
       reader.execute
     end
 
-    # Process function to request email from an imap server using the imap utility
+    # Process function to request GitHub issues using the octokit utility
     #
     def process
       octokit = Utils::Github::OctokitClient.new(params).execute
@@ -56,7 +99,8 @@ module Bot
         private_pem: process_options[:private_pem],
         app_id: process_options[:app_id],
         method: process_options[:method],
-        method_params: process_options[:method_params]
+        method_params: process_options[:method_params],
+        organization: process_options[:organization]
       }
     end
 

--- a/lib/bas/bot/fetch_github_issues.rb
+++ b/lib/bas/bot/fetch_github_issues.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/default"
+require_relative "../utils/github/octokit_client"
+require_relative "../write/postgres"
+
+module Bot
+  class FetchGithubIssues < Bot::Base
+    ISSUE_PARAMS = %i[id url title body labels state created_at updated_at].freeze
+    PER_PAGE = 100
+
+    # Read function to execute the default Read component
+    #
+    def read
+      reader = Read::Default.new
+
+      reader.execute
+    end
+
+    # Process function to request email from an imap server using the imap utility
+    #
+    def process
+      octokit = Utils::Github::OctokitClient.new(params).execute
+
+      if octokit[:client]
+        repo_issues = octokit[:client].issues(@process_options[:repo], filters)
+        issues = normalize_response(repo_issues)
+
+        { success: { issues: } }
+      else
+        { error: octokit[:error] }
+      end
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def params
+      {
+        private_pem: process_options[:private_pem],
+        app_id: process_options[:app_id],
+        method: process_options[:method],
+        method_params: process_options[:method_params]
+      }
+    end
+
+    def filters
+      default_filter = { per_page: PER_PAGE }
+      filters = @process_options[:filters]
+
+      filters.is_a?(Hash) ? default_filter.merge(filters) : default_filter
+    end
+
+    def normalize_response(issues)
+      issues.map do |issue|
+        ISSUE_PARAMS.reduce({}) { |hash, param| hash.merge({ param => issue.send(param) }) }
+      end
+    end
+  end
+end

--- a/lib/bas/bot/update_work_item.rb
+++ b/lib/bas/bot/update_work_item.rb
@@ -11,6 +11,44 @@ require_relative "../utils/notion/delete_page_blocks"
 require_relative "../write/postgres"
 
 module Bot
+  ##
+  # The Bot::UpdateWorkItem class serves as a bot implementation to update "work items" on a
+  # notion database using information of a GitHub issue.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "github_issues",
+  #       tag: "UpdateWorkItemRequest"
+  #     },
+  #     process_options: {
+  #       secret: "notion secret"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "github_issues",
+  #       tag: "UpdateWorkItem"
+  #     }
+  #   }
+  #
+  #   bot = Bot::UpdateWorkItem.new(options)
+  #   bot.execute
+  #
   class UpdateWorkItem < Bot::Base
     include Utils::Notion::Types
 
@@ -24,8 +62,8 @@ module Bot
       reader.execute
     end
 
-    # process function to execute the Notion utility to send formated blocks to a page
-    #
+    # process function to execute the Notion utility to update work items on a notion
+    # database
     def process
       return { success: { updated: nil } } if unprocessable_response
 

--- a/lib/bas/bot/update_work_item.rb
+++ b/lib/bas/bot/update_work_item.rb
@@ -31,7 +31,7 @@ module Bot
       response = Utils::Notion::Request.execute(params)
 
       if response.code == 200
-        { success: { updated: true } }
+        { success: { issue: read_response.data["issue"] } }
       else
         { error: { message: response.parsed_response, status_code: response.code } }
       end
@@ -70,7 +70,7 @@ module Bot
           {
             object: "block",
             type: "paragraph",
-            paragraph: rich_text("issue", read_response.data["issue"]["url"])
+            paragraph: rich_text("issue", read_response.data["issue"]["html_url"])
           }
         ]
       }

--- a/lib/bas/bot/update_work_item.rb
+++ b/lib/bas/bot/update_work_item.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "json"
+require "md_to_notion"
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../utils/notion/request"
+require_relative "../utils/notion/types"
+require_relative "../write/postgres"
+
+module Bot
+  class UpdateWorkItem < Bot::Base
+    include Utils::Notion::Types
+
+    DESCRIPTION = "Issue Description"
+
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options.merge(conditions))
+
+      reader.execute
+    end
+
+    # process function to execute the Notion utility to send formated blocks to a page
+    #
+    def process
+      return { success: { updated: nil } } if unprocessable_response
+
+      response = Utils::Notion::Request.execute(params)
+
+      if response.code == 200
+        { success: { updated: true } }
+      else
+        { error: { message: response.parsed_response, status_code: response.code } }
+      end
+    end
+
+    # write function to execute the PostgresDB write component
+    #
+    def write
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def conditions
+      {
+        where: "archived=$1 AND tag=$2 AND stage=$3 ORDER BY inserted_at ASC",
+        params: [false, read_options[:tag], "unprocessed"]
+      }
+    end
+
+    def params
+      {
+        endpoint: "blocks/#{read_response.data["notion_wi"]}/children",
+        secret: process_options[:secret],
+        method: "patch",
+        body:
+      }
+    end
+
+    def body
+      {
+        children: [
+          { object: "block", type: "toggle", toggle: },
+          {
+            object: "block",
+            type: "paragraph",
+            paragraph: rich_text("issue", read_response.data["issue"]["url"])
+          }
+        ]
+      }
+    end
+
+    def toggle
+      rich_text(description).merge({ children: toggle_childrens })
+    end
+
+    def description
+      date_time = Time.now.utc.strftime("%c")
+
+      "#{DESCRIPTION}/#{date_time}"
+    end
+
+    def toggle_childrens
+      MdToNotion::Parser.markdown_to_notion_blocks(read_response.data["issue"]["body"])
+    end
+  end
+end

--- a/lib/bas/bot/verify_issue_existance_in_notion.rb
+++ b/lib/bas/bot/verify_issue_existance_in_notion.rb
@@ -10,6 +10,8 @@ require_relative "../write/postgres"
 
 module Bot
   class VerifyIssueExistanceInNotion < Bot::Base
+    NOT_FOUND = "not found"
+
     # read function to execute the PostgresDB Read component
     #
     def read
@@ -72,7 +74,7 @@ module Bot
     end
 
     def notion_wi_id(result)
-      return if result.nil?
+      return NOT_FOUND if result.nil?
 
       result["id"]
     end
@@ -80,7 +82,9 @@ module Bot
     def tag
       issue = process_response[:success]
 
-      issue[:notion_wi].nil? ? "CreateWorkItemRequest" : "UpdateWorkItemRequest"
+      return write_options[:tag] if issue[:notion_wi].nil?
+
+      issue[:notion_wi].eql?(NOT_FOUND) ? "CreateWorkItemRequest" : "UpdateWorkItemRequest"
     end
   end
 end

--- a/lib/bas/bot/verify_issue_existance_in_notion.rb
+++ b/lib/bas/bot/verify_issue_existance_in_notion.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "json"
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../utils/notion/request"
+require_relative "../utils/notion/update_db_state"
+require_relative "../write/postgres"
+
+module Bot
+  class VerifyIssueExistanceInNotion < Bot::Base
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options.merge(conditions))
+
+      reader.execute
+    end
+
+    # process function to execute the Notion utility to send formated blocks to a page
+    #
+    def process
+      return { success: { issue: nil } } if unprocessable_response
+
+      response = Utils::Notion::Request.execute(params)
+
+      if response.code == 200
+        result = response.parsed_response["results"].first
+
+        { success: { issue: read_response.data["request"], notion_wi: notion_wi_id(result) } }
+      else
+        { error: { message: response.parsed_response, status_code: response.code } }
+      end
+    end
+
+    # write function to execute the PostgresDB write component
+    #
+    def write
+      options = write_options.merge({ tag: })
+
+      write = Write::Postgres.new(options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def conditions
+      {
+        where: "archived=$1 AND tag=$2 AND stage=$3 ORDER BY inserted_at ASC",
+        params: [false, read_options[:tag], "unprocessed"]
+      }
+    end
+
+    def params
+      {
+        endpoint: "databases/#{process_options[:database_id]}/query",
+        secret: process_options[:secret],
+        method: "post",
+        body:
+      }
+    end
+
+    def body
+      {
+        filter: {
+          property: "Github Issue id",
+          rich_text: { equals: read_response.data["request"]["id"].to_s }
+        }
+      }
+    end
+
+    def notion_wi_id(result)
+      return if result.nil?
+
+      result["id"]
+    end
+
+    def tag
+      issue = process_response[:success]
+
+      issue[:notion_wi].nil? ? "CreateWorkItemRequest" : "UpdateWorkItemRequest"
+    end
+  end
+end

--- a/lib/bas/bot/verify_issue_existance_in_notion.rb
+++ b/lib/bas/bot/verify_issue_existance_in_notion.rb
@@ -122,7 +122,7 @@ module Bot
     def tag
       issue = process_response[:success]
 
-      return write_options[:tag] if issue[:notion_wi].nil?
+      return write_options[:tag] if issue.nil? || issue[:notion_wi].nil?
 
       issue[:notion_wi].eql?(NOT_FOUND) ? "CreateWorkItemRequest" : "UpdateWorkItemRequest"
     end

--- a/lib/bas/bot/verify_issue_existance_in_notion.rb
+++ b/lib/bas/bot/verify_issue_existance_in_notion.rb
@@ -9,6 +9,45 @@ require_relative "../utils/notion/update_db_state"
 require_relative "../write/postgres"
 
 module Bot
+  ##
+  # The Bot::VerifyIssueExistanceInNotion class serves as a bot implementation to verify if a
+  # GitHub issue was already created on a notion database base on a column with the issue id.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "github_issues",
+  #       tag: "GithubIssueRequest"
+  #     },
+  #     process_options: {
+  #       database_id: "notion database id",
+  #       secret: "notion secret"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "github_issues",
+  #       tag: "VerifyIssueExistanceInNotio"
+  #     }
+  #   }
+  #
+  #   bot = Bot::VerifyIssueExistanceInNotion.new(options)
+  #   bot.execute
+  #
   class VerifyIssueExistanceInNotion < Bot::Base
     NOT_FOUND = "not found"
 
@@ -20,7 +59,8 @@ module Bot
       reader.execute
     end
 
-    # process function to execute the Notion utility to send formated blocks to a page
+    # process function to execute the Notion utility to verify GitHub issues existance
+    # on a notion database
     #
     def process
       return { success: { issue: nil } } if unprocessable_response

--- a/lib/bas/bot/write_github_issue_requests.rb
+++ b/lib/bas/bot/write_github_issue_requests.rb
@@ -7,7 +7,7 @@ require_relative "../write/postgres"
 module Bot
   ##
   # The Bot::WriteGithubIssueRequests class serves as a bot implementation to write GitHub issues
-  # request to be sent indiviadualy.
+  # request to be sent individually.
   #
   # <br>
   # <b>Example</b>

--- a/lib/bas/bot/write_github_issue_requests.rb
+++ b/lib/bas/bot/write_github_issue_requests.rb
@@ -5,6 +5,52 @@ require_relative "../read/postgres"
 require_relative "../write/postgres"
 
 module Bot
+  ##
+  # The Bot::WriteGithubIssueRequests class serves as a bot implementation to write GitHub issues
+  # request to be sent indiviadualy.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     read_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "github_issues",
+  #       tag: "FetchGithubIssues"
+  #     },
+  #     process_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "github_issues",
+  #       tag: "GithubIssueRequest"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "github_issues",
+  #       tag: "WriteGithubIssueRequests"
+  #     }
+  #   }
+  #
+  #   bot = Bot::WriteGithubIssueRequests.new(options)
+  #   bot.execute
+  #
   class WriteGithubIssueRequests < Bot::Base
     # read function to execute the PostgresDB Read component
     #
@@ -14,7 +60,7 @@ module Bot
       reader.execute
     end
 
-    # Process function to execute the Notion utility create single review requests
+    # Process function to write GitHub issues requests.
     #
     def process
       return { success: { created: nil } } if unprocessable_response

--- a/lib/bas/bot/write_github_issue_requests.rb
+++ b/lib/bas/bot/write_github_issue_requests.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../write/postgres"
+
+module Bot
+  class WriteGithubIssueRequests < Bot::Base
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Postgres.new(read_options.merge(conditions))
+
+      reader.execute
+    end
+
+    # Process function to execute the Notion utility create single review requests
+    #
+    def process
+      return { success: { created: nil } } if unprocessable_response
+
+      read_response.data["issues"].each { |request| create_request(request) }
+
+      { success: { created: true } }
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def conditions
+      {
+        where: "archived=$1 AND tag=$2 AND stage=$3 ORDER BY inserted_at ASC",
+        params: [false, read_options[:tag], "unprocessed"]
+      }
+    end
+
+    def create_request(request)
+      write_data = { success: { request: } }
+
+      Write::Postgres.new(process_options, write_data).execute
+    end
+  end
+end

--- a/lib/bas/utils/github/octokit_client.rb
+++ b/lib/bas/utils/github/octokit_client.rb
@@ -31,7 +31,7 @@ module Utils
       def access_token
         app = Octokit::Client.new(client_id: @params[:app_id], bearer_token: jwt)
 
-        installation_id = app.find_organization_installation("FGSoffice").id
+        installation_id = app.find_organization_installation(@params[:organization]).id
 
         app.create_app_installation_access_token(installation_id)[:token]
       end

--- a/lib/bas/utils/github/octokit_client.rb
+++ b/lib/bas/utils/github/octokit_client.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "octokit"
+require "openssl"
+require "jwt"
+
+module Utils
+  module Github
+    ##
+    # This module is a Imap utility for request emails from an Imap server
+    #
+    class OctokitClient
+      def initialize(params)
+        @params = params
+      end
+
+      # Execute the imap requets after authenticate the email with the credentials
+      #
+      def execute
+        { client: octokit }
+      rescue StandardError => e
+        { error: e.to_s }
+      end
+
+      private
+
+      def octokit
+        Octokit::Client.new(bearer_token: access_token)
+      end
+
+      def access_token
+        app = Octokit::Client.new(client_id: @params[:app_id], bearer_token: jwt)
+
+        installation_id = app.find_organization_installation("FGSoffice").id
+
+        app.create_app_installation_access_token(installation_id)[:token]
+      end
+
+      def jwt
+        private_key = OpenSSL::PKey::RSA.new(@params[:private_pem])
+
+        JWT.encode(jwt_payload, private_key, "RS256")
+      end
+
+      def jwt_payload
+        {
+          iat: Time.now.to_i - 60,
+          exp: Time.now.to_i + (10 * 60),
+          iss: @params[:app_id]
+        }
+      end
+    end
+  end
+end

--- a/lib/bas/utils/github/octokit_client.rb
+++ b/lib/bas/utils/github/octokit_client.rb
@@ -7,14 +7,14 @@ require "jwt"
 module Utils
   module Github
     ##
-    # This module is a Imap utility for request emails from an Imap server
+    # This module is a Github utility for making requests to the Github API using the octokit module
     #
     class OctokitClient
       def initialize(params)
         @params = params
       end
 
-      # Execute the imap requets after authenticate the email with the credentials
+      # Build the octokit client using a Github app access token
       #
       def execute
         { client: octokit }

--- a/lib/bas/utils/notion/delete_page_blocks.rb
+++ b/lib/bas/utils/notion/delete_page_blocks.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "httparty"
+require_relative "request"
+
+module Utils
+  module Notion
+    ##
+    # This module is a Notion utility for deleting page blocks.
+    #
+    class DeletePageBlocks
+      # Implements the delete page blocks process logic to Notion.
+      #
+      # <br>
+      # <b>Params:</b>
+      # * <tt>page_id</tt> Id of the notion page.
+      # * <tt>secret</tt> Notion secret.
+      #
+      # <br>
+      # <b>returns</b> <tt>HTTParty::Response</tt>
+      #
+      #
+      def initialize(params)
+        @params = params
+      end
+
+      def execute
+        page_blocks_ids.each { |block_id| delete_block(block_id) }
+      end
+
+      private
+
+      def page_blocks_ids
+        page = Utils::Notion::Request.execute(page_params)
+
+        page.parsed_response["results"].map { |block| block["id"] }
+      end
+
+      def page_params
+        {
+          endpoint: "blocks/#{@params[:page_id]}/children",
+          secret: @params[:secret],
+          method: "get",
+          body: {}
+        }
+      end
+
+      def delete_block(block_id)
+        params = delete_params(block_id)
+
+        Utils::Notion::Request.execute(params)
+      end
+
+      def delete_params(block_id)
+        {
+          endpoint: "blocks/#{block_id}",
+          secret: @params[:secret],
+          method: "delete",
+          body: {}
+        }
+      end
+    end
+  end
+end

--- a/lib/bas/utils/notion/types.rb
+++ b/lib/bas/utils/notion/types.rb
@@ -2,6 +2,10 @@
 
 module Utils
   module Notion
+    ##
+    # This module is a Notion utility for formating standard notion types to
+    # filter or create.
+    #
     module Types
       def multi_select(name)
         { "multi_select" => [{ "name" => name }] }

--- a/lib/bas/utils/notion/types.rb
+++ b/lib/bas/utils/notion/types.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Utils
+  module Notion
+    module Types
+      def multi_select(name)
+        { "multi_select" => [{ "name" => name }] }
+      end
+
+      def relation(id)
+        { relation: [{ id: }] }
+      end
+
+      def select(name)
+        { select: { name: } }
+      end
+
+      def rich_text(content)
+        { rich_text: [{ text: { content: } }] }
+      end
+
+      def status(name)
+        { status: { name: } }
+      end
+
+      def title(content)
+        { title: [{ text: { content: } }] }
+      end
+    end
+  end
+end

--- a/lib/bas/utils/notion/types.rb
+++ b/lib/bas/utils/notion/types.rb
@@ -15,8 +15,12 @@ module Utils
         { select: { name: } }
       end
 
-      def rich_text(content)
-        { rich_text: [{ text: { content: } }] }
+      def rich_text(content, url = nil)
+        text = { content: }
+
+        text = text.merge({ link: { url: } }) unless url.nil?
+
+        { rich_text: [{ text: }] }
       end
 
       def status(name)

--- a/spec/bas/bot/create_work_item_spec.rb
+++ b/spec/bas/bot/create_work_item_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require "bas/bot/create_work_item"
+
+RSpec.describe Bot::CreateWorkItem do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "github_issues",
+        tag: "CreateWorkItemRequest"
+      },
+      process_options: {
+        database_id: "database id",
+        secret: "notion secret",
+        domain: "domain",
+        status: "Backlog",
+        work_item_type: "project",
+        project: "project_id"
+      },
+      write_options: {
+        connection:,
+        db_table: "github_issues",
+        tag: "CreateWorkItem"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:issue_result) do
+      "{\"issue\":\
+      {\"id\": \"12345\", \"body\": \"simple description\",\
+      \"state\": \"open\", \"title\": \"Issue\", \"labels\": [],\
+       \"html_url\":\"https://github.com/repo/issues\", \"assignees\": [],\
+       \"created_at\":\"2024-07-24 20:13:18 UTC\",\
+       \"updated_at\":\"2024-07-24 20:36:57 UTC\"}, \"notion_wi\": \"not found\"\
+      }"
+    end
+
+    let(:formatted_issue) do
+      { "issue" => {
+        "id" => "12345",
+        "body" => "simple description",
+        "state" => "open",
+        "title" => "Issue",
+        "labels" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "assignees" => [],
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:36:57 UTC"
+      }, "notion_wi" => "not found" }
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[1, issue_result, "date"]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_issue)
+    end
+  end
+
+  describe ".process" do
+    let(:work_item) { { "id" => "123456789" } }
+
+    let(:issue) do
+      {
+        "id" => "12345",
+        "body" => "simple description",
+        "state" => "open",
+        "title" => "Issue",
+        "labels" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "assignees" => [],
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:36:57 UTC"
+      }
+    end
+
+    let(:issue_request) { { "issue" => issue } }
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    let(:response) { double("http_response") }
+
+    before do
+      @bot.read_response = Read::Types::Response.new(1, issue_request, "date")
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "creates a work item on notion and returns its notion id" do
+      allow(response).to receive(:code).and_return(200)
+      allow(response).to receive(:[]).and_return("123456789")
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { issue:, notion_wi: "123456789" } })
+    end
+
+    it "returns an error hash with the error message" do
+      allow(response).to receive(:code).and_return(404)
+      allow(response).to receive(:parsed_response).and_return(error_response)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ error: { message: error_response, status_code: 404 } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:issue) do
+      {
+        "id" => "12345",
+        "body" => "simple description",
+        "state" => "open",
+        "title" => "Issue",
+        "labels" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "assignees" => [],
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:36:57 UTC"
+      }
+    end
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response with 'UpdateWorkItemRequest' tag when it has a notion wi" do
+      @bot.process_response = { success: { issue:, notion_wi: "123456789" } }
+
+      expect(@bot.write).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      @bot.process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end

--- a/spec/bas/bot/fetch_github_issues_spec.rb
+++ b/spec/bas/bot/fetch_github_issues_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require "bas/bot/fetch_github_issues"
+
+RSpec.describe Bot::FetchGithubIssues do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "github_issues",
+        tag: "FetchGithubIssues",
+        avoid_process: true
+      },
+      process_options: {
+        private_pem: "private_pem",
+        app_id: "app_id",
+        repo: "repo",
+        filters: { state: "open" }
+      },
+      write_options: {
+        connection:,
+        db_table: "github_issues",
+        tag: "FetchGithubIssues"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:issues_results) do
+      "{\"issues\": [\
+      {\"id\": \"12345\", \"body\": \"simple description\",\
+      \"state\": \"open\", \"title\": \"Issue\", \"labels\": [],\
+       \"html_url\":\"https://github.com/repo/issues\", \"assignees\": [],\
+       \"created_at\":\"2024-07-24 20:13:18 UTC\",\
+       \"updated_at\":\"2024-07-24 20:36:57 UTC\"}\
+      ]}"
+    end
+
+    let(:formatted_issues) do
+      { "issues" => [{
+        "id" => "12345",
+        "body" => "simple description",
+        "state" => "open",
+        "title" => "Issue",
+        "labels" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "assignees" => [],
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:36:57 UTC"
+      }] }
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[1, issues_results, "date"]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_issues)
+    end
+  end
+
+  describe ".process" do
+    let(:issue) do
+      double("issue", "id" => "12345",
+                      "html_url" => "https://github.com/repo/issues",
+                      "title" => "Issue",
+                      "body" => "simple description",
+                      "labels" => [],
+                      "state" => "open",
+                      "created_at" => "2024-07-24 20:13:18 UTC",
+                      "updated_at" => "2024-07-24 20:13:18 UTC",
+                      "assignees" => [])
+    end
+
+    let(:issues_results) do
+      "{\"issues\": [\
+      {\"id\": \"12345\", \"body\": \"simple description\",\
+      \"state\": \"open\", \"title\": \"Issue\", \"labels\": [],\
+       \"html_url\":\"https://github.com/repo/issues\", \"assignees\": [],\
+       \"created_at\":\"2024-07-24 20:13:18 UTC\",\
+       \"updated_at\":\"2024-07-24 20:36:57 UTC\"}\
+      ]}"
+    end
+
+    let(:formatted_issues) do
+      {
+        id: "12345",
+        assignees: [],
+        html_url: "https://github.com/repo/issues",
+        title: "Issue",
+        body: "simple description",
+        labels: [],
+        state: "open",
+        created_at: "2024-07-24 20:13:18 UTC",
+        updated_at: "2024-07-24 20:13:18 UTC"
+      }
+    end
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    let(:octokit) { double("octokit") }
+
+    before do
+      @bot.read_response = Read::Types::Response.new
+
+      allow(OpenSSL::PKey::RSA).to receive(:new).and_return("private key")
+      allow(JWT).to receive(:encode).and_return("jwt")
+
+      allow(octokit).to receive(:create_app_installation_access_token).and_return({ token: "token" })
+      allow(octokit).to receive(:find_organization_installation).and_return(double(id: 12_345))
+      allow(octokit).to receive(:issues).and_return([issue])
+    end
+
+    it "returns a success hash with the list of formatted GitHub issues" do
+      allow(Octokit::Client).to receive(:new).and_return(octokit)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { issues: [formatted_issues] } })
+    end
+
+    it "returns a success hash with the list of formatted birthdays" do
+      allow(Octokit::Client).to receive(:new).and_return(octokit)
+
+      @bot.read_response = Read::Types::Response.new(1, issues_results, "date")
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { issues: [formatted_issues] } })
+    end
+
+    it "returns an error hash with the error message" do
+      allow(Octokit::Client).to receive(:new).and_raise(StandardError)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ error: "StandardError" })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:formatted_issues) do
+      {
+        id: "12345",
+        assignees: [],
+        html_url: "https://github.com/repo/issues",
+        title: "Issue",
+        body: "simple description",
+        labels: [],
+        state: "open",
+        created_at: "2024-07-24 20:13:18 UTC",
+        updated_at: "2024-07-24 20:13:18 UTC"
+      }
+    end
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      @bot.process_response = { success: { issues: [formatted_issues] } }
+
+      expect(@bot.write).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      @bot.process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end

--- a/spec/bas/bot/update_work_item_spec.rb
+++ b/spec/bas/bot/update_work_item_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require "bas/bot/update_work_item"
+
+RSpec.describe Bot::UpdateWorkItem do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "github_issues",
+        tag: "UpdateWorkItemRequest"
+      },
+      process_options: {
+        secret: "notion secret"
+      },
+      write_options: {
+        connection:,
+        db_table: "github_issues",
+        tag: "UpdateWorkItem"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:issue_result) do
+      "{\"issue\":\
+      {\"id\": \"12345\", \"body\": \"simple description\",\
+      \"state\": \"open\", \"title\": \"Issue\", \"labels\": [],\
+       \"html_url\":\"https://github.com/repo/issues\", \"assignees\": [],\
+       \"created_at\":\"2024-07-24 20:13:18 UTC\",\
+       \"updated_at\":\"2024-07-24 20:36:57 UTC\"}, \"notion_wi\": \"123456789\"\
+      }"
+    end
+
+    let(:formatted_issue) do
+      { "issue" => {
+        "id" => "12345",
+        "body" => "simple description",
+        "state" => "open",
+        "title" => "Issue",
+        "labels" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "assignees" => [],
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:36:57 UTC"
+      }, "notion_wi" => "123456789" }
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[1, issue_result, "date"]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_issue)
+    end
+  end
+
+  describe ".process" do
+    let(:work_item) { { "id" => "123456789" } }
+
+    let(:issue) do
+      {
+        "id" => "12345",
+        "body" => "simple description",
+        "state" => "open",
+        "title" => "Issue",
+        "labels" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "assignees" => [],
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:36:57 UTC"
+      }
+    end
+
+    let(:issue_request) { { "issue" => issue } }
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    let(:response) { double("http_response") }
+
+    before do
+      @bot.read_response = Read::Types::Response.new(1, issue_request, "date")
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "creates a work item on notion and returns its notion id" do
+      allow(response).to receive(:code).and_return(200)
+      allow(response).to receive(:parsed_response).and_return({ "results" => [work_item] })
+      allow(response).to receive(:[]).and_return("123456789")
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { issue: } })
+    end
+
+    it "returns an error hash with the error message" do
+      allow(response).to receive(:code).and_return(404)
+      allow(response).to receive(:parsed_response).and_return({ "results" => [work_item] }, error_response)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ error: { message: error_response, status_code: 404 } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:issue) do
+      {
+        "id" => "12345",
+        "body" => "simple description",
+        "state" => "open",
+        "title" => "Issue",
+        "labels" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "assignees" => [],
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:36:57 UTC"
+      }
+    end
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response with 'UpdateWorkItemRequest' tag when it has a notion wi" do
+      @bot.process_response = { success: { issue: } }
+
+      expect(@bot.write).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      @bot.process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end

--- a/spec/bas/bot/verify_issue_existance_in_notion_spec.rb
+++ b/spec/bas/bot/verify_issue_existance_in_notion_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "bas/bot/verify_issue_existance_in_notion"
+
+RSpec.describe Bot::VerifyIssueExistanceInNotion do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "github_issues",
+        tag: "GithubIssueRequest"
+      },
+      process_options: {
+        database_id: "database id",
+        secret: "notion secret"
+      },
+      write_options: {
+        connection:,
+        db_table: "github_issues",
+        tag: "VerifyIssueExistanceInNotio"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:issue_result) do
+      "{\"issue\":\
+      {\"id\": \"12345\", \"body\": \"simple description\",\
+      \"state\": \"open\", \"title\": \"Issue\", \"labels\": [],\
+       \"html_url\":\"https://github.com/repo/issues\", \"assignees\": [],\
+       \"created_at\":\"2024-07-24 20:13:18 UTC\",\
+       \"updated_at\":\"2024-07-24 20:36:57 UTC\"}\
+      }"
+    end
+
+    let(:formatted_issue) do
+      { "issue" => {
+        "id" => "12345",
+        "body" => "simple description",
+        "state" => "open",
+        "title" => "Issue",
+        "labels" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "assignees" => [],
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:36:57 UTC"
+      } }
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[1, issue_result, "date"]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_issue)
+    end
+  end
+
+  describe ".process" do
+    let(:work_item) { { "id" => "123456789" } }
+
+    let(:issue) do
+      {
+        "id" => "12345",
+        "body" => "simple description",
+        "state" => "open",
+        "title" => "Issue",
+        "labels" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "assignees" => [],
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:36:57 UTC"
+      }
+    end
+
+    let(:issue_request) { { "request" => issue } }
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    let(:response) { double("http_response") }
+
+    before do
+      @bot.read_response = Read::Types::Response.new(1, issue_request, "date")
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "set the work item id when it exist on notion" do
+      allow(response).to receive(:code).and_return(200)
+      allow(response).to receive(:parsed_response).and_return({ "results" => [work_item] })
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { issue:, notion_wi: "123456789" } })
+    end
+
+    it "set the work item id as 'not found' when it doesn't exist on notion" do
+      allow(response).to receive(:code).and_return(200)
+      allow(response).to receive(:parsed_response).and_return({ "results" => [] })
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { issue:, notion_wi: "not found" } })
+    end
+
+    it "returns an error hash with the error message" do
+      allow(response).to receive(:code).and_return(404)
+      allow(response).to receive(:parsed_response).and_return(error_response)
+
+      processed = @bot.process
+
+      expect(processed).to eq({ error: { message: error_response, status_code: 404 } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:issue) do
+      {
+        "id" => "12345",
+        "body" => "simple description",
+        "state" => "open",
+        "title" => "Issue",
+        "labels" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "assignees" => [],
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:36:57 UTC"
+      }
+    end
+
+    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response with 'UpdateWorkItemRequest' tag when it has a notion wi" do
+      @bot.process_response = { success: { issue:, notion_wi: "123456789" } }
+
+      expect(@bot.write).to_not be_nil
+    end
+
+    it "save the process success response with 'CreateWorkItemRequest' tag when it doesn't have a notion wi" do
+      @bot.process_response = { success: { issue:, notion_wi: "not found" } }
+
+      expect(@bot.write).to_not be_nil
+    end
+
+    it "save the process fail response in a postgres table" do
+      @bot.process_response = { error: { message: error_response, status_code: 404 } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end

--- a/spec/bas/bot/write_github_issue_requests_spec.rb
+++ b/spec/bas/bot/write_github_issue_requests_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "bas/bot/write_github_issue_requests"
+
+RSpec.describe Bot::WriteGithubIssueRequests do
+  before do
+    connection = {
+      host: "localhost",
+      port: 5432,
+      dbname: "bas",
+      user: "postgres",
+      password: "postgres"
+    }
+
+    config = {
+      read_options: {
+        connection:,
+        db_table: "github_issues",
+        tag: "FetchGithubIssues"
+      },
+      process_options: {
+        connection:,
+        db_table: "github_issues",
+        tag: "GithubIssueRequest"
+      },
+      write_options: {
+        connection:,
+        db_table: "github_issues",
+        tag: "WriteGithubIssueRequests"
+      }
+    }
+
+    @bot = described_class.new(config)
+  end
+
+  describe "attributes and arguments" do
+    it { expect(described_class).to respond_to(:new).with(1).arguments }
+
+    it { expect(@bot).to respond_to(:execute).with(0).arguments }
+    it { expect(@bot).to respond_to(:read).with(0).arguments }
+    it { expect(@bot).to respond_to(:process).with(0).arguments }
+    it { expect(@bot).to respond_to(:write).with(0).arguments }
+
+    it { expect(@bot).to respond_to(:read_options) }
+    it { expect(@bot).to respond_to(:process_options) }
+    it { expect(@bot).to respond_to(:write_options) }
+  end
+
+  describe ".read" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+    let(:issues_results) do
+      "{\"issues\": [\
+      {\"id\": \"12345\", \"body\": \"simple description\",\
+      \"state\": \"open\", \"title\": \"Issue\", \"labels\": [],\
+       \"html_url\":\"https://github.com/repo/issues\", \"assignees\": [],\
+       \"created_at\":\"2024-07-24 20:13:18 UTC\",\
+       \"updated_at\":\"2024-07-24 20:36:57 UTC\"}\
+      ]}"
+    end
+
+    let(:formatted_issues) do
+      { "issues" => [{
+        "id" => "12345",
+        "body" => "simple description",
+        "state" => "open",
+        "title" => "Issue",
+        "labels" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "assignees" => [],
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:36:57 UTC"
+      }] }
+    end
+
+    before do
+      @pg_result = double
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(@pg_result)
+      allow(@pg_result).to receive(:values).and_return([[1, issues_results, "date"]])
+    end
+
+    it "read the notification from the postgres database" do
+      read = @bot.read
+
+      expect(read).to be_a Read::Types::Response
+      expect(read.data).to be_a Hash
+      expect(read.data).to_not be_nil
+      expect(read.data).to eq(formatted_issues)
+    end
+  end
+
+  describe ".process" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    let(:issues_request) do
+      { "issues" => [{
+        "id" => "12345",
+        "assignees" => [],
+        "html_url" => "https://github.com/repo/issues",
+        "title" => "Issue",
+        "body" => "simple description",
+        "labels" => [],
+        "state" => "open",
+        "created_at" => "2024-07-24 20:13:18 UTC",
+        "updated_at" => "2024-07-24 20:13:18 UTC"
+      }] }
+    end
+
+    let(:response) { double("http_response") }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+
+      @bot.read_response = Read::Types::Response.new
+
+      allow(HTTParty).to receive(:send).and_return(response)
+    end
+
+    it "returns an empty success hash when the media list is empty" do
+      @bot.read_response = Read::Types::Response.new(1, { "issues" => [] }, "date")
+
+      expect(@bot.process).to eq({ success: { created: nil } })
+    end
+
+    it "returns an empty success hash when the record was not found" do
+      @bot.read_response = Read::Types::Response.new(1, nil, "date")
+
+      expect(@bot.process).to eq({ success: { created: nil } })
+    end
+
+    it "returns a success hash after writting the requests in the shared storage" do
+      @bot.read_response = Read::Types::Response.new(1, issues_request, "date")
+
+      processed = @bot.process
+
+      expect(processed).to eq({ success: { created: true } })
+    end
+  end
+
+  describe ".write" do
+    let(:pg_conn) { instance_double(PG::Connection) }
+
+    before do
+      pg_result = instance_double(PG::Result)
+
+      allow(PG::Connection).to receive(:new).and_return(pg_conn)
+      allow(pg_conn).to receive(:exec_params).and_return(pg_result)
+    end
+
+    it "save the process success response in a postgres table" do
+      @bot.process_response = { success: { created: true } }
+
+      expect(@bot.write).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Description
On this PR, the bots for the synchronized Github issues with a notion database were added. For this:
- Added FetchGithubIssues bot
- Added WriteGithubIssueRequests bot
- Added VerifyIssueExistanceInNotion bot
- Added CreateWorkItem bot
- Added UpdateWorkItem bot

Closes #87 

Example of use: 
```ruby
connection = {
  host: "localhost",
  port: 5432,
  dbname: "bas",
  user: "postgres",
  password: "postgres"
}

# UPDATE WORK ITEM
options = {
  read_options: {
    connection:,
    db_table: "github_issues",
    tag: "UpdateWorkItemRequest"
  },
  process_options: {
    secret: "notion secret"
  },
  write_options: {
    connection:,
    db_table: "github_issues",
    tag: "UpdateWorkItem"
  }
}

bot = Bot::UpdateWorkItem.new(options)
bot.execute

# CREATE WORK ITEM
options = {
  read_options: {
    connection:,
    db_table: "github_issues",
    tag: "CreateWorkItemRequest"
  },
  process_options: {
    database_id: "notion database id",
    secret: "notion secret",
    domain: "domain name",
    status: "Backlog",
    work_item_type: "project",
    project: "project id"
  },
  write_options: {
    connection:,
    db_table: "github_issues",
    tag: "CreateWorkItem"
  }
}

bot = Bot::CreateWorkItem.new(options)
bot.execute

# VERIFY EXISTENCE
options = {
  read_options: {
    connection:,
    db_table: "github_issues",
    tag: "GithubIssueRequest"
  },
  process_options: {
    database_id: "notion database id",
    secret: "notion secret"
  },
  write_options: {
    connection:,
    db_table: "github_issues",
    tag: "VerifyIssueExistanceInNotio"
  }
}

bot = Bot::VerifyIssueExistanceInNotion.new(options)
bot.execute

# WRITE ISSUES REQUESTS
options = {
  read_options: {
    connection:,
    db_table: "github_issues",
    tag: "FetchGithubIssues"
  },
  process_options: {
    connection:,
    db_table: "github_issues",
    tag: "GithubIssueRequest"
  },
  write_options: {
    connection:,
    db_table: "github_issues",
    tag: "WriteGithubIssueRequests"
  }
}

bot = Bot::WriteGithubIssueRequests.new(options)
bot.execute

# FETCH GITHUB ISSUES
options = {
  read_options: {
    connection:,
    db_table: "github_issues",
    tag: "FetchGithubIssues",
    avoid_process: true
  },
  process_options: {
    private_pem:,
    app_id:,
    repo:,
    filters: { state: "open" },
    organization: "organization name"
  },
  write_options: {
    connection:,
    db_table: "github_issues",
    tag: "FetchGithubIssues"
  }
}

bot = Bot::FetchGithubIssues.new(options)
bot.execute
```