### PR TITLE
Adjusted Digital Ocean billing alerts.

### DIFF
--- a/lib/bas/bot/format_do_bill_alert.rb
+++ b/lib/bas/bot/format_do_bill_alert.rb
@@ -49,14 +49,16 @@ module Bot
     #
     def read
       reader = Read::Postgres.new(read_options.merge(conditions))
+      data = reader.execute
 
-      reader.execute
+      @billing_data = data.first || {}
+      @last_updated = parse_last_updated(@billing_data["updated_at"])
     end
 
     # Process function to format the notification using a template
     #
     def process
-      return { success: { notification: "" } } if unprocessable_response || !threshold_exceeded
+      return { success: { notification: "" } } if skip_processing?
 
       { success: { notification: message } }
     end
@@ -64,17 +66,26 @@ module Bot
     # Write function to execute the PostgresDB write component
     #
     def write
-      write = Write::Postgres.new(write_options, process_response)
+      writer = Write::Postgres.new(write_options, process_response)
 
-      write.execute
+      writer.execute
     end
 
     private
 
+    def current_month_data?
+      return false unless @last_updated
+
+      current_month = Time.now.utc.month
+      last_updated_month = @last_updated.month
+
+      current_month == last_updated_month
+    end
+
     def conditions
       {
-        where: "archived=$1 AND tag=$2 AND stage=$3 ORDER BY inserted_at ASC",
-        params: [false, read_options[:tag], "unprocessed"]
+        where: "archived=$1 AND tag=$2 AND stage=$3 AND EXTRACT(MONTH FROM inserted_at) = $4 ORDER BY inserted_at ASC",
+        params: [false, read_options[:tag], "unprocessed", Time.now.utc.month]
       }
     end
 
@@ -82,20 +93,62 @@ module Bot
       daily_usage > process_options[:threshold]
     end
 
+    def projected_threshold_exceeded
+      projected_month_total > process_options[:threshold]
+    end
+
     def daily_usage
-      balance = read_response.data["billing"]["month_to_date_balance"].to_f
+      balance = current_balance
       day_of_month = Time.now.utc.mday
 
       balance / day_of_month
     end
 
+    def projected_month_total
+      balance = current_balance
+      days_in_month = total_days_in_month
+      today = current_day_of_month
+
+      average_daily_cost = calculate_average_daily_cost(balance, today)
+      remaining_days = days_in_month - today
+
+      balance + (average_daily_cost * remaining_days)
+    end
+
     def message
-      balance = read_response.data["billing"]["month_to_date_balance"]
+      balance = current_balance
       threshold = process_options[:threshold]
+      projected_total = projected_month_total
 
       ":warning: The **DigitalOcean** daily usage was exceeded. \
-      Current balance: #{balance}, Threshold: #{threshold}, \
-      Current daily usage: #{daily_usage.round(3)}"
+        Current balance: #{balance}, Threshold: #{threshold}, \
+        Current daily usage: #{daily_usage.round(3)}, \
+        Projected end-of-month total: #{projected_total.round(2)}, \
+        Last updated: #{@last_updated.strftime("%Y-%m-%d %H:%M:%S")}"
+    end
+
+    def parse_last_updated(updated_at)
+      Time.parse(updated_at) if updated_at
+    end
+
+    def skip_processing?
+      unprocessable_response || !threshold_exceeded || !current_month_data?
+    end
+
+    def current_balance
+      @billing_data["billing"]["month_to_date_balance"].to_f
+    end
+
+    def total_days_in_month
+      Time.days_in_month(Time.now.month, Time.now.year)
+    end
+
+    def current_day_of_month
+      Time.now.utc.mday
+    end
+
+    def calculate_average_daily_cost(balance, today)
+      balance / today
     end
   end
 end


### PR DESCRIPTION
1.- Previously the code did not check if the billing data that was been processed corresponded to the current month, it will just read the data as it was on the DB, we added a check to verify that only data from the current month is being processed, this is done throng the `current_month_data?` method which help us avoid incorrect alerts such as the ones we were experimenting.

2.- Previously the code was not filtering entries by insert month, so we added a condition to filter by current month, making sure all the data is relevant to the current month.

3.- Previously we were not doing a monthly projection, which might hinder the ability to anticipate expenses and take preemptive measures to avoid that problem, so I adde the projected month total, to account for a manual calculation based on the current expending habits.

Missing testing still.