### PR TITLE
Solve #99 - Adjust website monitoring use case notifications

### DIFF
--- a/lib/bas/bot/fetch_billing_from_digital_ocean.rb
+++ b/lib/bas/bot/fetch_billing_from_digital_ocean.rb
@@ -81,9 +81,7 @@ module Bot
     end
 
     def last_billing
-      return read_response.data["billing"] unless read_response.data.nil?
-
-      { month_to_date_balance: 0 }
+      read_response.data.nil? ? nil : read_response.data["billing"]
     end
   end
 end

--- a/lib/bas/bot/review_domain_availability.rb
+++ b/lib/bas/bot/review_domain_availability.rb
@@ -90,12 +90,7 @@ module Bot
     end
 
     def notification(response)
-      data = {
-        domain: read_response.data["url"],
-        status_code: response.code
-      }
-
-      ":warning: Domain is down: #{data}"
+      ":warning: The Domain #{read_response.data["url"]} is down with an error code of #{response.code}"
     end
   end
 end

--- a/spec/bas/bot/fetch_billing_from_digital_ocean_spec.rb
+++ b/spec/bas/bot/fetch_billing_from_digital_ocean_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Bot::FetchBillingFromDigitalOcean do
 
       processed = @bot.process
 
-      expect(processed).to eq({ success: { billing: do_bill, last_billing: { month_to_date_balance: 0 } } })
+      expect(processed).to eq({ success: { billing: do_bill, last_billing: nil } })
     end
 
     it "returns a success hash with the digital ocean bill when a last billing was not found" do


### PR DESCRIPTION
## Description
On this PR, the web availability bot notification was enhanced. Now, when the bot finds a website with an error, the notification message will follow this template: 
```ruby
:warning: The Domain https://crimson-shadow-3724.fly.dev/ is down with an error code of 404
```

Closes #99 