### PR TITLE
Create bot to fetch images from a Discord channel of all threads

### DIFF
--- a/lib/bas/bot/fetch_images_from_discord.rb
+++ b/lib/bas/bot/fetch_images_from_discord.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "./base"
+require_relative "../read/postgres"
+require_relative "../utils/discord/request"
+
+module Bot
+  ##
+  # The Bot::FetchMediaFromNotion class serves as a bot implementation to read media (text or images)
+  # from a notion database and write them on a PostgresDB table with a specific format.
+  #
+  # <br>
+  # <b>Example</b>
+  #
+  #   options = {
+  #     process_options: {
+  #       secret_token: "discord_bot_token"
+  #       discord_channel: "discord_channel_id"
+  #     },
+  #     write_options: {
+  #       connection: {
+  #         host: "localhost",
+  #         port: 5432,
+  #         dbname: "bas",
+  #         user: "postgres",
+  #         password: "postgres"
+  #       },
+  #       db_table: "review_media",
+  #       tag: "FetchImagesFromDiscord"
+  #     }
+  #   }
+  #
+  #   bot = Bot::FetchImagesFromDiscord.new(options)
+  #   bot.execute
+  #
+  class FetchImagesFromDiscord < Bot::Base # rubocop:disable Metrics/ClassLength
+
+    # read function to execute the PostgresDB Read component
+    #
+    def read
+      reader = Read::Default.new
+
+      reader.execute
+    end
+
+    # Process function to execute the Notion utility to fetch media from a notion database
+    #
+    def process
+      response = Utils::Discord::Request.get_recent_thread_messages(recent_messages)
+
+      if response.code == 200
+        ## WIP: to verify
+      else
+        { error: { message: response.parsed_response, status_code: response.code } }
+      end
+    end
+
+    # Write function to execute the PostgresDB write component
+    #
+    def write
+      write = Write::Postgres.new(write_options, process_response)
+
+      write.execute
+    end
+
+    private
+
+    def params
+      {
+        endpoint: "channels/#{process_options[:discord_channel]}/messages",
+        channel_id: process_options[:secret_token]
+        secret_token: process_options[:secret_token],
+        body: {}
+      }
+    end
+  end
+end

--- a/lib/bas/bot/fetch_images_from_discord.rb
+++ b/lib/bas/bot/fetch_images_from_discord.rb
@@ -26,7 +26,7 @@ module Bot
   #         user: "postgres",
   #         password: "postgres"
   #       },
-  #       db_table: "review_media",
+  #       db_table: "review_images",
   #       tag: "FetchImagesFromDiscord"
   #     }
   #   }
@@ -35,7 +35,7 @@ module Bot
   #   bot.execute
   #
   class FetchImagesFromDiscord < Bot::Base
-    # read function to execute the PostgresDB Read component
+    # read function to execute the Default Read component
     #
     def read
       reader = Read::Default.new

--- a/lib/bas/bot/review_media.rb
+++ b/lib/bas/bot/review_media.rb
@@ -32,7 +32,7 @@ module Bot
   #     process_options: {
   #       secret: "openai_secret",
   #       assistant_id: "openai_assistant_id",
-  #       media_type: "paragraph"
+  #       media_type: "images"
   #     },
   #     write_options: {
   #       connection: {
@@ -115,19 +115,13 @@ module Bot
       read_response.data["media"]
     end
 
-    def notion_format(response)
-      md_response = response.parsed_response["data"].first["content"].first["text"]["value"]
-
-      MdToNotion::Parser.markdown_to_notion_blocks(md_response).to_json
-    end
-
     def sucess_response(response)
-      review = notion_format(response)
-      page_id = read_response.data["page_id"]
-      created_by = read_response.data["created_by"]
+      review = response.parsed_response["data"].first["content"].first["text"]["value"]
+      thread_id = read_response.data["thread_id"]
       property = read_response.data["property"]
+      author = read_response.data["author"]
 
-      { success: { review:, page_id:, created_by:, property:, media_type: process_options[:media_type] } }
+      { success: { review:, thread_id:, property:, author:, media_type: process_options[:media_type] } }
     end
 
     def error_response(response)

--- a/lib/bas/bot/review_media.rb
+++ b/lib/bas/bot/review_media.rb
@@ -71,7 +71,7 @@ module Bot
         return error_response(response)
       end
 
-      sucess_response(response)
+      success_response(response)
     end
 
     # write function to execute the PostgresDB write component
@@ -114,13 +114,22 @@ module Bot
       read_response.data["media"]
     end
 
-    def sucess_response(response)
-      review = response.parsed_response["data"].first["content"].first["text"]["value"]
-      thread_id = read_response.data["thread_id"]
-      property = read_response.data["property"]
-      author = read_response.data["author"]
+    def success_response(response)
+      review = get_review(response)
+      { success: media_hash.merge({ review: }) }
+    end
 
-      { success: { review:, thread_id:, property:, author:, media_type: process_options[:media_type] } }
+    def get_review(response)
+      response.parsed_response["data"].first["content"].first["text"]["value"]
+    end
+
+    def media_hash
+      {
+        thread_id: read_response.data["thread_id"],
+        property: read_response.data["property"],
+        author: read_response.data["author"],
+        media_type: process_options[:media_type]
+      }
     end
 
     def error_response(response)

--- a/lib/bas/bot/review_media.rb
+++ b/lib/bas/bot/review_media.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "md_to_notion"
 require "json"
 
 require_relative "./base"
@@ -11,8 +10,8 @@ require_relative "../utils/openai/run_assistant"
 module Bot
   ##
   # The Bot::ReviewMedia class serves as a bot implementation to read from a postgres
-  # shared storage a set of review media requests and create single request on the shared storage to
-  # be processed one by one.
+  # shared storage a images hash with a specific format and create single request
+  # on the shared storage to be processed one by one.
   #
   # <br>
   # <b>Example</b>

--- a/lib/bas/bot/write_media_review_in_discord.rb
+++ b/lib/bas/bot/write_media_review_in_discord.rb
@@ -5,6 +5,7 @@ require "json"
 require_relative "./base"
 require_relative "../read/postgres"
 require_relative "../write/postgres"
+require_relative "../utils/discord/request"
 
 module Bot
   ##
@@ -61,7 +62,7 @@ module Bot
 
       response = Utils::Discord::Request.write_media_text(params)
 
-      if !response.nil?
+      if response.code == 200
         { success: { thread_id: read_response.data["thread_id"], property: read_response.data["property"] } }
       else
         { error: { message: response.parsed_response, status_code: response.code } }

--- a/lib/bas/bot/write_media_review_in_discord.rb
+++ b/lib/bas/bot/write_media_review_in_discord.rb
@@ -8,7 +8,7 @@ require_relative "../write/postgres"
 
 module Bot
   ##
-  # The Bot::WriteMediaReviewInNotion class serves as a bot implementation to read from a postgres
+  # The Bot::WriteMediaReviewInDiscord class serves as a bot implementation to read from a postgres
   # shared storage images object blocks and send them to a thread of Discord channel
   #
   # <br>
@@ -54,7 +54,7 @@ module Bot
       reader.execute
     end
 
-    # process function to execute the Discord utility to send image feedback to a thread of Discord channel
+    # process function to execute the Discord utility to send image feedback to a thread of a Discord channel
     #
     def process
       return { success: { review_added: nil } } if unprocessable_response

--- a/lib/bas/bot/write_media_review_requests.rb
+++ b/lib/bas/bot/write_media_review_requests.rb
@@ -23,8 +23,8 @@ module Bot
   #         user: "postgres",
   #         password: "postgres"
   #       },
-  #       db_table: "review_media",
-  #       tag: "FetchMediaFromNotion"
+  #       db_table: "review_images",
+  #       tag: "FetchMediaFromDiscord"
   #     },
   #     process_options: {
   #       connection: {
@@ -34,7 +34,7 @@ module Bot
   #         user: "postgres",
   #         password: "postgres"
   #       },
-  #       db_table: "review_media",
+  #       db_table: "review_images",
   #       tag: "ReviewMediaRequest"
   #     },
   #     write_options: {
@@ -45,7 +45,7 @@ module Bot
   #         user: "postgres",
   #         password: "postgres"
   #       },
-  #       db_table: "review_media",
+  #       db_table: "review_images",
   #       tag: "WriteMediaReviewRequests"
   #     }
   #   }
@@ -54,8 +54,6 @@ module Bot
   #   bot.execute
   #
   class WriteMediaReviewRequests < Bot::Base
-    IN_PROCESS_STATE = "in process"
-
     # read function to execute the PostgresDB Read component
     #
     def read
@@ -64,7 +62,7 @@ module Bot
       reader.execute
     end
 
-    # Process function to execute the Notion utility create single review requests
+    # Process function to execute the Discord utility create single review requests
     #
     def process
       return { success: { created: nil } } if unprocessable_response
@@ -100,20 +98,7 @@ module Bot
     def write_request(request)
       return { error: request } if request["media"].empty? || !request["error"].nil?
 
-      update_state(request)
-
       { success: request }
-    end
-
-    def update_state(request)
-      data = {
-        property: request["property"],
-        page_id: request["page_id"],
-        state: IN_PROCESS_STATE,
-        secret: process_options[:secret]
-      }
-
-      Utils::Notion::UpdateDbState.execute(data)
     end
   end
 end

--- a/lib/bas/utils/discord/request.rb
+++ b/lib/bas/utils/discord/request.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module Utils
+  module Discord
+    module Request
+      DISCORD_BASE_URL = "https://discord.com/api/v10"
+
+      # Implements the request process logic to Discord.
+      #
+      # <br>
+      # <b>Params:</b>
+      # * <tt>method</tt> HTTP request method: post, get, put, etc.
+      # * <tt>body</tt> Request body (Hash).
+      # * <tt>endpoint</tt> Notion resource endpoint.
+      # * <tt>secret_token</tt> Discord Bot Token.
+      #
+      # <br>
+      #
+      #
+      def self.execute(params)
+        url = URI.parse("#{DISCORD_BASE_URL}/#{params[:endpoint]}")
+
+        http = Net::HTTP.new(url.host, url.port)
+        http.use_ssl = true
+
+        request = Net::HTTP::Get.new(url.request_uri)
+        request['Authorization'] = "Bot #{params[:secret_token]}"
+
+        response = http.request(request)
+        JSON.parse(response.body) if response.is_a?(Net::HTTPSuccess)
+      end
+
+      def self.get_recent_thread_messages(channel_id, secret_token)
+        recent_messages = {}
+        current_time = Time.now
+
+        messages = execute(channel_id, secret_token)
+
+        thread_ids = messages.select { |msg| msg['type'] == 18 }.map { |msg| msg['id'] }
+
+        thread_ids.each do |thread_id|
+          thread_messages = execute(thread_id, secret_token)
+
+          thread_messages.each do |message|
+            message_time = Time.parse(message['timestamp'])
+            if (current_time - message_time) < 60 && !message['content'].nil?
+              attachment = message["attachments"].first
+              recent_messages[message['id']] = {
+                filename: attachment['filename'],
+                url: attachment['url'],
+                author: message['author']['username'],
+                timestamp: message['timestamp']
+              }
+            end
+          end
+        end
+
+        recent_messages
+      end
+    end
+  end
+end

--- a/lib/bas/utils/discord/request.rb
+++ b/lib/bas/utils/discord/request.rb
@@ -11,6 +11,8 @@ module Utils
     # Discord channel.
     #
     module Request
+      DISCORD_BASE_URL = "https://discord.com/api/v10"
+
       # Implements the request process logic to Discord.
       #
       # <br>

--- a/lib/bas/utils/discord/request.rb
+++ b/lib/bas/utils/discord/request.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
-require 'net/http'
-require 'json'
-require 'uri'
+require "json"
+require "uri"
+require "httparty"
+require "time"
 
 module Utils
   module Discord
+    ##
+    # This module is a Discord utility for obtain all images of any threads of a
+    # Discord channel.
+    #
     module Request
       DISCORD_BASE_URL = "https://discord.com/api/v10"
 
@@ -23,43 +28,60 @@ module Utils
       #
       def self.execute(params)
         url = URI.parse("#{DISCORD_BASE_URL}/#{params[:endpoint]}")
-
-        http = Net::HTTP.new(url.host, url.port)
-        http.use_ssl = true
-
-        request = Net::HTTP::Get.new(url.request_uri)
-        request['Authorization'] = "Bot #{params[:secret_token]}"
-
-        response = http.request(request)
-        JSON.parse(response.body) if response.is_a?(Net::HTTPSuccess)
+        headers = headers(params[:secret_token])
+        response = HTTParty.send(params[:method], url, { headers: })
+        JSON.parse(response.body)
       end
 
-      def self.get_recent_thread_messages(channel_id, secret_token)
-        recent_messages = {}
+      def self.get_thread_messages(params)
+        recent_messages = []
         current_time = Time.now
+        messages = execute(params)
+        thread_ids = messages.select { |msg| msg["type"] == 18 }.map { |msg| msg["id"] }
 
-        messages = execute(channel_id, secret_token)
-
-        thread_ids = messages.select { |msg| msg['type'] == 18 }.map { |msg| msg['id'] }
+        return if thread_ids.empty?
 
         thread_ids.each do |thread_id|
-          thread_messages = execute(thread_id, secret_token)
+          thread_messages = get_threads(thread_id, params)
 
           thread_messages.each do |message|
-            message_time = Time.parse(message['timestamp'])
-            if (current_time - message_time) < 60 && !message['content'].nil?
-              attachment = message["attachments"].first
-              recent_messages[message['id']] = {
-                filename: attachment['filename'],
-                url: attachment['url'],
-                author: message['author']['username'],
-                timestamp: message['timestamp']
-              }
-            end
+            message_time = Time.parse(message["timestamp"])
+
+            next unless (current_time - message_time) < 60 && message["attachments"]
+
+            images_urls = message["attachments"].map { |attachment| attachment["url"] }
+
+            next if images_urls.empty?
+
+            recent_messages << {
+              "media" => images_urls,
+              "thread_id" => thread_id,
+              "author" => message["author"]["username"],
+              "timestamp" => message["timestamp"],
+              "property" => "images"
+            }
           end
         end
-
         recent_messages
+      end
+
+      def self.get_threads(thread_id, params)
+        url = URI.parse("#{DISCORD_BASE_URL}/channels/#{thread_id}/messages")
+        headers = headers(params[:secret_token])
+        HTTParty.get(url, { headers: })
+      end
+
+      def self.write_media_text(params)
+        url = URI.parse("#{DISCORD_BASE_URL}/#{params[:endpoint]}")
+        headers = headers(params[:secret_token])
+        HTTParty.send(params[:method], url, { body: params[:body].to_json, headers: })
+      end
+
+      def self.headers(secret_token)
+        {
+          "Authorization" => secret_token.to_s,
+          "Content-Type" => "application/json"
+        }
       end
     end
   end

--- a/spec/bas/bot/write_media_review_in_discord_spec.rb
+++ b/spec/bas/bot/write_media_review_in_discord_spec.rb
@@ -94,7 +94,8 @@ RSpec.describe Bot::WriteMediaReviewInDiscord do
 
       processed = @bot.process
 
-      expect(processed).to eq({ success: { thread_id: review_request["thread_id"], property: review_request["property"] } })
+      expect(processed).to eq({ success: { thread_id: review_request["thread_id"],
+                                           property: review_request["property"] } })
     end
 
     it "returns an error hash with the error message" do

--- a/spec/bas/bot/write_media_review_in_discord_spec.rb
+++ b/spec/bas/bot/write_media_review_in_discord_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "bas/bot/write_media_review_in_notion"
+require "bas/bot/write_media_review_in_discord"
 
-RSpec.describe Bot::WriteMediaReviewInNotion do
+RSpec.describe Bot::WriteMediaReviewInDiscord do
   before do
     connection = {
       host: "localhost",
@@ -15,16 +15,16 @@ RSpec.describe Bot::WriteMediaReviewInNotion do
     config = {
       read_options: {
         connection:,
-        db_table: "use_cases",
+        db_table: "review_media",
         tag: "FormatMediaReview"
       },
       process_options: {
-        secret: "secret"
+        secret_token: "discord_bot_token"
       },
       write_options: {
         connection:,
-        db_table: "use_cases",
-        tag: "WriteMediaReviewInNotion"
+        db_table: "review_media",
+        tag: "WriteMediaReviewInDiscord"
       }
     }
 
@@ -47,13 +47,13 @@ RSpec.describe Bot::WriteMediaReviewInNotion do
   describe ".read" do
     let(:pg_conn) { instance_double(PG::Connection) }
     let(:review_request_results) do
-      "{ \"created_by\": \"1234567\", \"review\": \"simple text\",\"page_id\":
-      \"review_table_request\", \"property\": \"paragraph\", \"media_type\": \"paragraph\" }"
+      "{ \"author\": \"user\", \"review\": \"simple text\", \"property\": \"images\",
+        \"thread_id\": \"1285685692772646922\", \"media_type\": \"images\" }"
     end
 
     let(:review_request) do
-      { "created_by" => "1234567", "review" => "simple text",
-        "page_id" => "review_table_request", "property" => "paragraph", "media_type" => "paragraph" }
+      { "author" => "user", "review" => "simple text", "property" => "images",
+        "thread_id" => "1285685692772646922", "media_type" => "images" }
     end
 
     before do
@@ -76,30 +76,30 @@ RSpec.describe Bot::WriteMediaReviewInNotion do
 
   describe ".process" do
     let(:review_request) do
-      { "created_by" => "1234567", "review" => "{\"children\": \"simple text\"}",
-        "page_id" => "review_table_request", "property" => "paragraph", "media_type" => "paragraph" }
+      { "author" => "user", "review" => "simple text", "property" => "images",
+        "thread_id" => "1285685692772646922", "media_type" => "images" }
     end
 
     let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
 
-    let(:response) { double("http_response") }
+    let(:response) { double("https_response") }
 
     before do
       @bot.read_response = Read::Types::Response.new(1, review_request, "date")
-
       allow(HTTParty).to receive(:send).and_return(response)
     end
 
-    it "returns a success hash with page and property to be updated" do
+    it "returns a success hash with thread_id and property to be updated" do
       allow(response).to receive(:code).and_return(200)
 
       processed = @bot.process
 
-      expect(processed).to eq({ success: { page_id: review_request["page_id"], property: review_request["property"] } })
+      expect(processed).to eq({ success: { thread_id: review_request["thread_id"], property: review_request["property"] } })
     end
 
     it "returns an error hash with the error message" do
       allow(response).to receive(:code).and_return(404)
+
       allow(response).to receive(:parsed_response).and_return(error_response)
 
       processed = @bot.process


### PR DESCRIPTION
-Updated the logic to retrieve images and text from a specific Discord channel instead of fetching data from the Notion database.
-Implemented new methods to fetch and process messages from Discord, ensuring compatibility with the existing functionality.

Closes [#103](https://github.com/kommitters/bas/issues/103)