### PR TITLE
Refactor Discord bots logic to conform with discord_bot

### DIFF
--- a/lib/bas/bot/review_media.rb
+++ b/lib/bas/bot/review_media.rb
@@ -50,8 +50,6 @@ module Bot
   #   bot.execute
   #
   class ReviewMedia < Bot::Base
-    DETAIL = "low"
-
     # read function to execute the PostgresDB Read component
     #
     def read
@@ -125,7 +123,8 @@ module Bot
 
     def media_hash
       {
-        thread_id: read_response.data["thread_id"],
+        message_id: read_response.data["message_id"],
+        channel_id: read_response.data["channel_id"],
         property: read_response.data["property"],
         author: read_response.data["author"],
         media_type: process_options[:media_type]

--- a/lib/bas/bot/write_media_review_in_discord.rb
+++ b/lib/bas/bot/write_media_review_in_discord.rb
@@ -63,7 +63,7 @@ module Bot
       response = Utils::Discord::Request.write_media_text(params)
 
       if response.code == 200
-        { success: { thread_id: read_response.data["thread_id"], property: read_response.data["property"] } }
+        { success: { message_id: read_response.data["message_id"], property: read_response.data["property"] } }
       else
         { error: { message: response.parsed_response, status_code: response.code } }
       end
@@ -88,10 +88,10 @@ module Bot
 
     def params
       {
-        endpoint: "channels/#{read_response.data["thread_id"]}/messages",
+        body:,
         secret_token: process_options[:secret_token],
-        method: "post",
-        body:
+        message_id: read_response.data["message_id"],
+        channel_id: read_response.data["channel_id"]
       }
     end
 

--- a/lib/bas/utils/discord/request.rb
+++ b/lib/bas/utils/discord/request.rb
@@ -31,7 +31,8 @@ module Utils
 
         {
           "media" => images_urls,
-          "thread_id" => message.id,
+          "message_id" => message.id,
+          "channel_id" => message.channel.id,
           "author" => message.author.username,
           "timestamp" => message.timestamp.to_s,
           "property" => "images"
@@ -39,9 +40,10 @@ module Utils
       end
 
       def self.write_media_text(params)
-        url = URI.parse("#{DISCORD_BASE_URL}/#{params[:endpoint]}")
+        url_message = URI.parse("#{DISCORD_BASE_URL}/channels/#{params[:channel_id]}/messages")
+        message_body = { content: params[:body] }
         headers = headers(params[:secret_token])
-        HTTParty.send(params[:method], url, { body: params[:body].to_json, headers: })
+        HTTParty.post(url_message, { body: message_body.to_json, headers: })
       end
 
       def self.headers(secret_token)

--- a/spec/bas/bot/write_media_review_in_discord_spec.rb
+++ b/spec/bas/bot/write_media_review_in_discord_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe Bot::WriteMediaReviewInDiscord do
     let(:pg_conn) { instance_double(PG::Connection) }
     let(:review_request_results) do
       "{ \"author\": \"user\", \"review\": \"simple text\", \"property\": \"images\",
-        \"thread_id\": \"1285685692772646922\", \"media_type\": \"images\" }"
+        \"message_id\": \"1285685692772646922\", \"channel_id\": \"1285685692772646933\", \"media_type\": \"images\"  }"
     end
 
     let(:review_request) do
       { "author" => "user", "review" => "simple text", "property" => "images",
-        "thread_id" => "1285685692772646922", "media_type" => "images" }
+        "message_id" => "1285685692772646922", "channel_id" => "1285685692772646933", "media_type" => "images" }
     end
 
     before do
@@ -77,7 +77,7 @@ RSpec.describe Bot::WriteMediaReviewInDiscord do
   describe ".process" do
     let(:review_request) do
       { "author" => "user", "review" => "simple text", "property" => "images",
-        "thread_id" => "1285685692772646922", "media_type" => "images" }
+        "message_id" => "1285685692772646922", "channel_id" => "1285685692772646933", "media_type" => "images" }
     end
 
     let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
@@ -86,15 +86,15 @@ RSpec.describe Bot::WriteMediaReviewInDiscord do
 
     before do
       @bot.read_response = Read::Types::Response.new(1, review_request, "date")
-      allow(HTTParty).to receive(:send).and_return(response)
+      allow(HTTParty).to receive(:post).and_return(response)
     end
 
-    it "returns a success hash with thread_id and property to be updated" do
+    it "returns a success hash with message_id and property to be updated" do
       allow(response).to receive(:code).and_return(200)
 
       processed = @bot.process
 
-      expect(processed).to eq({ success: { thread_id: review_request["thread_id"],
+      expect(processed).to eq({ success: { message_id: review_request["message_id"],
                                            property: review_request["property"] } })
     end
 


### PR DESCRIPTION
Refactor the current logic handling Discord bots to conform with the new discord_bot implementation

Tasks:
-Modify the logic in Utils::Discord::Request so that when a new image is uploaded, it returns a hash with additional data
-Update write_media_text method for sending the feedback message for images to respond directly in a private chat.

Closes #105 