### PR TITLE
Refactor Discord bot logic to split response messages in paragraphs

### DIFF
--- a/lib/bas/bot/write_media_review_in_discord.rb
+++ b/lib/bas/bot/write_media_review_in_discord.rb
@@ -60,12 +60,12 @@ module Bot
     def process
       return { success: { review_added: nil } } if unprocessable_response
 
-      response = Utils::Discord::Request.write_media_text(params)
+      response = Utils::Discord::Request.split_paragraphs(params)
 
-      if response.code == 200
+      if !response.empty?
         { success: { message_id: read_response.data["message_id"], property: read_response.data["property"] } }
       else
-        { error: { message: response.parsed_response, status_code: response.code } }
+        { error: { message: "Response is empty" } }
       end
     end
 
@@ -88,27 +88,11 @@ module Bot
 
     def params
       {
-        body:,
+        body: read_response.data["review"],
         secret_token: process_options[:secret_token],
         message_id: read_response.data["message_id"],
         channel_id: read_response.data["channel_id"]
       }
-    end
-
-    def body
-      { content: "#{toggle_title}\n\n#{read_response.data["review"]}\n\n#{mention_content}" }
-    end
-
-    def mention_content
-      author_name = read_response.data["author"]
-      "<@#{author_name}>"
-    end
-
-    def toggle_title
-      case read_response.data["media_type"]
-      when "images" then "Image review results"
-      when "paragraph" then "Text review results"
-      end
     end
   end
 end

--- a/lib/bas/utils/discord/request.rb
+++ b/lib/bas/utils/discord/request.rb
@@ -48,7 +48,7 @@ module Utils
       end
 
       def self.split_paragraphs(params)
-        paragraphs = params[:body].split("--PARAGRAPH--").map(&:strip).reject(&:empty?)
+        paragraphs = params[:body].split("--DIVISION--").map(&:strip).reject(&:empty?)
 
         paragraphs.each_slice(2) do |paragraph|
           next if paragraph.empty?

--- a/lib/bas/utils/discord/request.rb
+++ b/lib/bas/utils/discord/request.rb
@@ -39,10 +39,23 @@ module Utils
         }
       end
 
-      def self.write_media_text(params)
+      def self.write_media_text(params, combined_paragraphs)
         url_message = URI.parse("#{DISCORD_BASE_URL}/channels/#{params[:channel_id]}/messages")
         headers = headers(params[:secret_token])
-        HTTParty.post(url_message, { body: params[:body].to_json, headers: })
+        body = { content: combined_paragraphs }.to_json
+
+        HTTParty.post(url_message, { body:, headers: })
+      end
+
+      def self.split_paragraphs(params)
+        paragraphs = params[:body].split("--PARAGRAPH--").map(&:strip).reject(&:empty?)
+
+        paragraphs.each_slice(2) do |paragraph|
+          next if paragraph.empty?
+
+          combined_paragraphs = paragraph.join("\n\n")
+          write_media_text(params, combined_paragraphs)
+        end
       end
 
       def self.headers(secret_token)

--- a/spec/bas/bot/write_media_review_in_discord_spec.rb
+++ b/spec/bas/bot/write_media_review_in_discord_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Bot::WriteMediaReviewInDiscord do
         "message_id" => "1285685692772646922", "channel_id" => "1285685692772646933", "media_type" => "images" }
     end
 
-    let(:error_response) { { "object" => "error", "status" => 404, "message" => "not found" } }
+    let(:error_response) { { "object" => "error", "message" => "Response is empty" } }
 
     let(:response) { double("https_response") }
 
@@ -99,13 +99,11 @@ RSpec.describe Bot::WriteMediaReviewInDiscord do
     end
 
     it "returns an error hash with the error message" do
-      allow(response).to receive(:code).and_return(404)
-
-      allow(response).to receive(:parsed_response).and_return(error_response)
+      allow(Utils::Discord::Request).to receive(:split_paragraphs).and_return([])
 
       processed = @bot.process
 
-      expect(processed).to eq({ error: { message: error_response, status_code: 404 } })
+      expect(processed).to eq({ error: { message: "Response is empty" } })
     end
   end
 


### PR DESCRIPTION
On this PR a new logic was implemented to split OpenAI image review response into paragraphs to avoid Discord API error with characters. `({"message": {"code": 50035, "errors": {"content": {"_errors": [{"code": "BASE_TYPE_MAX_LENGTH", "message": "Must be 2000 or fewer in length."}]}}, "message": "Invalid Form Body"}, "status_code": 400})`

Now:

- The OpenAI image review response generates `review` key with `--PARAGRAPH--` word, so that afterward,
- Discord Utils splits every two paragraphs with `--PARAGRAPH--` and sends each split to private message, avoiding the Discord API error 