### PR TITLE
Solve #122 - Bots with default shared storage reader are not saving data

### DIFF
--- a/lib/bas/bot/base.rb
+++ b/lib/bas/bot/base.rb
@@ -46,8 +46,7 @@ module Bas
       def write
         return if @process_options[:avoid_empty_data] && empty_data?
 
-        data = unprocessable_response ? { success: {} } : process_response
-        @shared_storage_writer.write(data)
+        @shared_storage_writer.write(process_response)
       end
 
       def empty_data?

--- a/spec/bas/bot/base_spec.rb
+++ b/spec/bas/bot/base_spec.rb
@@ -149,15 +149,6 @@ RSpec.describe Bas::Bot::Base do
       expect(@shared_storage_writer).to have_received(:write).with({})
     end
 
-    it "write an { succes : {} } when the response is unprocessable" do
-      allow(read_response).to receive(:data).and_return({})
-      allow(@shared_storage_writer).to receive(:write).and_return({})
-
-      @bot.execute
-
-      expect(@shared_storage_writer).to have_received(:write).with({ success: {} })
-    end
-
     it "ignore write if avoid_empty_data is set to true on options" do
       options = { avoid_empty_data: true }
       bot = described_class.new(options, @shared_storage_reader, @shared_storage_writer)


### PR DESCRIPTION
Closes #122 

## Description
On this PR, the default condition to manage unprocessable responses was removed from the bot/base class to avoid errors for the bots that use the default shared storage reader. 