### PR TITLE
fix: update path script execution

### DIFF
--- a/lib/bas/orchestrator/manager.rb
+++ b/lib/bas/orchestrator/manager.rb
@@ -85,7 +85,9 @@ module Bas
 
       def execute(script)
         puts "Executing #{script[:path]} at #{current_time}"
-        system("ruby ", script[:path])
+        absolute_path = File.expand_path(script[:path], __dir__)
+
+        system("ruby", absolute_path)
       end
     end
   end


### PR DESCRIPTION
fix absolute_path in order to execute the scripts in the bas_use_cases repositorie 