### PR TITLE
feat(manager): add support for custom scheduling rules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,4 +29,5 @@ group :test do
   gem "net-smtp", "~> 0.4.0.1"
   gem "octokit", "~> 8.1.0"
   gem "openssl", "~> 3.2"
+  gem "timecop"
 end

--- a/lib/bas/orchestrator/manager.rb
+++ b/lib/bas/orchestrator/manager.rb
@@ -11,6 +11,7 @@ module Bas
     # This class initializes a thread pool and processes scheduled scripts based on
     # time intervals, specific days, or exact times.
     #
+    # rubocop:disable Metrics/ClassLength
     class Manager
       def initialize(schedules)
         @last_executions = Hash.new(0.0)
@@ -31,15 +32,19 @@ module Bas
         loop do
           @actual_time = Time.new
 
-          execute_interval(script) if interval?(script)
-          execute_day(script) if day?(script) && time?(script)
-          execute_time(script) if time?(script) && !day?(script)
-          execute_custom_rule(script, @actual_time) if custom_rule?(script)
+          procces_schedule(script)
 
           sleep 0.1
         rescue StandardError => e
           puts "Error in thread: #{e.message}"
         end
+      end
+
+      def procces_schedule(script)
+        execute_interval(script) if interval?(script)
+        execute_day(script) if day?(script) && time?(script)
+        execute_time(script) if time?(script) && !day?(script)
+        execute_custom_rule(script, @actual_time) if custom_rule?(script)
       end
 
       def execute_interval(script)
@@ -61,26 +66,55 @@ module Bas
         @last_executions[script[:path]] = current_time
       end
 
+      # rubocop:disable Metrics/MethodLength
       def execute_custom_rule(script, current_moment)
         rule = script[:custom_rule]
         case rule[:type]
         when "last_day_of_week_in_month"
           execute_last_day_of_week_in_month(script, rule, current_moment)
-        # when "last_day_of_month"
-        #   exceute_last_day_of_month(script, rule, current_moment)
+        when "last_day_of_month"
+          execute_last_day_of_month(script, rule, current_moment)
+        when "last_day_of_week"
+          execute_last_day_of_week(script, rule, current_moment)
+        when "last_day_of_year"
+          execute_last_day_of_year(script, rule, current_moment)
         else
           puts "Unknown custom rule type: #{rule[:type]} for script '#{script[:path]}'"
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       def execute_last_day_of_week_in_month(script, rule, current_moment)
-        time_str_from_moment = current_moment.strftime("%H:%M")
-        return unless rule[:time]&.include?(time_str_from_moment)
-
+        return unless rule[:time]&.include?(current_moment.strftime("%H:%M"))
         return unless today_is_last_day_of_week_in_month?(current_moment, rule[:day_of_week])
 
-        execute(script) unless @last_executions.fetch(script[:path], nil).eql?(time_str_from_moment)
-        @last_executions[script[:path]] = time_str_from_moment
+        execute_once_per_time(script, current_moment.strftime("%H:%M"))
+      end
+
+      def execute_last_day_of_month(script, rule, current_moment)
+        return unless rule[:time]&.include?(current_moment.strftime("%H:%M"))
+        return unless current_moment.to_date == end_of_month(current_moment.to_date)
+
+        execute_once_per_time(script, current_moment.strftime("%H:%M"))
+      end
+
+      def execute_last_day_of_week(script, rule, current_moment)
+        return unless rule[:time]&.include?(current_moment.strftime("%H:%M"))
+
+        target_wday = Date::DAYNAMES.index { |name| name.casecmp(rule[:day_of_week]).zero? }
+        return if target_wday.nil?
+
+        today = current_moment.to_date
+        return unless today.wday == target_wday && last_occurrence_in_week?(today, target_wday)
+
+        execute_once_per_time(script, current_moment.strftime("%H:%M"))
+      end
+
+      def execute_last_day_of_year(script, rule, current_moment)
+        return unless rule[:time]&.include?(current_moment.strftime("%H:%M"))
+        return unless current_moment.month == 12 && current_moment.day == 31
+
+        execute_once_per_time(script, current_moment.strftime("%H:%M"))
       end
 
       def interval?(script)
@@ -112,32 +146,38 @@ module Bas
       end
 
       def today_is_last_day_of_week_in_month?(time_obj, target_day_name)
-        date = time_obj.to_date 
-        target_wday = Date::DAYNAMES.index { |name| name.casecmp(target_day_name) == 0 }
+        date = time_obj.to_date
+        target_wday = Date::DAYNAMES.index { |name| name.casecmp(target_day_name).zero? }
 
         return false if target_wday.nil?
         return false unless date.wday == target_wday
 
-        year = date.year
-        month = date.month
+        last_target_day_of_month?(date)
+      end
 
-        first_day_of_next_month = if month == 12
-                                    Date.new(year + 1, 1, 1)
-                                  else
-                                    Date.new(year, month + 1, 1)
-                                  end
+      def last_occurrence_in_week?(date, target_wday)
+        current_date = date
+        next_occurrence = current_date + 7
+        next_occurrence.wday == target_wday && last_target_day_of_month?(current_date)
+      end
 
-        last_day_of_current_month = first_day_of_next_month - 1
-        current_check_date = last_day_of_current_month
-        loop do
-          break if current_check_date.month != month
+      def last_target_day_of_month?(date)
+        current_date = date
+        next_occurrence = current_date + 7
 
-          if current_check_date.wday == target_wday
-            return date == current_check_date
-          end
-          current_check_date -= 1
-        end
-        false 
+        next_occurrence.month != current_date.month
+      end
+
+      def end_of_month(date)
+        next_month = date.month == 12 ? Date.new(date.year + 1, 1, 1) : Date.new(date.year, date.month + 1, 1)
+        next_month - 1
+      end
+
+      def execute_once_per_time(script, execution_time)
+        return if @last_executions[script[:path]] == execution_time
+
+        execute(script)
+        @last_executions[script[:path]] = execution_time
       end
 
       def execute(script)
@@ -147,5 +187,6 @@ module Bas
         system("ruby", absolute_path)
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/spec/bas/orchestrator/manager_spec.rb
+++ b/spec/bas/orchestrator/manager_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "bas/orchestrator/manager"
+require 'timecop'
 
 RSpec.describe Bas::Orchestrator::Manager do
   let(:schedules) do
@@ -10,7 +11,8 @@ RSpec.describe Bas::Orchestrator::Manager do
       { path: "websites_availability/notify_domain_availability.rb", interval: 60_000 },
       { path: "websites_availability/garbage_collector.rb", time: ["00:00"] },
       { path: "pto_next_week/fetch_next_week_pto_from_notion.rb", time: ["12:40"], day: ["Monday"] },
-      { path: "pto/fetch_pto_from_notion.rb", time: ["13:10"] }
+      { path: "pto/fetch_pto_from_notion.rb", time: ["13:10"] },
+      { path: "example/custom_last_friday.rb", custom_rule: { type: "last_day_of_week_in_month", day_of_week: "Friday", time: ["15:00"] } }
     ]
   end
 
@@ -21,6 +23,10 @@ RSpec.describe Bas::Orchestrator::Manager do
     allow(manager).to receive(:current_day).and_return("Monday")
     allow(manager).to receive(:time_in_milliseconds).and_return(10_000)
     allow(manager).to receive(:system).and_return(true)
+  end
+
+  after do
+    Timecop.return
   end
 
   describe "#execute_interval" do
@@ -75,6 +81,84 @@ RSpec.describe Bas::Orchestrator::Manager do
       expect { manager.send(:execute_day, script) }.not_to(change do
         manager.instance_variable_get(:@last_executions)[script[:path]]
       end)
+    end
+  end
+
+  describe "#execute_custom_rule" do
+    let(:custom_script) { schedules.find { |s| s[:custom_rule] && s[:custom_rule][:type] == "last_day_of_week_in_month" } }
+
+    context "for 'last_day_of_week_in_month' rule type" do
+      before do
+        allow(manager).to receive(:execute).with(custom_script).and_return(true)
+      end
+
+      it "executes script if all conditions are met (time from moment, date logic stubbed true)" do
+        current_moment_at_15_00 = Time.local(2023, 1, 1, 15, 0, 0)
+
+        allow(manager).to receive(:today_is_last_day_of_week_in_month?)
+          .with(current_moment_at_15_00, custom_script.dig(:custom_rule, :day_of_week))
+          .and_return(true)
+
+        expect(manager).to receive(:execute).with(custom_script)
+        expect {
+          manager.send(:execute_custom_rule, custom_script, current_moment_at_15_00)
+        }.to change { manager.instance_variable_get(:@last_executions)[custom_script[:path]] }.to("15:00")
+      end
+    end
+
+    context "for an unknown custom rule type" do
+      it "puts an error message and does not execute" do
+        unknown_rule_script = { path: "unknown_script.rb", custom_rule: { type: "some_future_rule" } }
+        current_moment = Time.now
+
+        expect(manager).not_to receive(:execute)
+        
+        expect {
+          manager.send(:execute_custom_rule, unknown_rule_script, current_moment)
+        }.to output(/Unknown custom rule type: some_future_rule for script 'unknown_script.rb'/).to_stdout_from_any_process
+      end
+    end
+  end
+
+  describe "#today_is_last_day_of_week_in_month?(time_obj, target_day_name)" do
+    def check_is_last_day_of_week(time_obj, target_day_name)
+      manager.send(:today_is_last_day_of_week_in_month?, time_obj, target_day_name)
+    end
+
+    context "when target_day_name is 'Friday'" do
+      let(:target_day_name) { "Friday" }
+
+      it "returns true for the last Friday of May 2024 (May 31, 2024)" do
+        a_moment_on_last_friday = Time.local(2024, 5, 31, 10, 0, 0)
+        expect(check_is_last_day_of_week(a_moment_on_last_friday, target_day_name)).to be true
+      end
+
+      it "returns false for a Friday that is not the last in the month (May 24, 2024)" do
+        a_moment_on_a_friday = Time.local(2024, 5, 24, 10, 0, 0)
+        expect(check_is_last_day_of_week(a_moment_on_a_friday, target_day_name)).to be false
+      end
+
+      it "returns false for a day that is not the target day (e.g., last Thursday of May 2024)" do
+        a_moment_on_a_thursday = Time.local(2024, 5, 30, 10, 0, 0)
+        expect(check_is_last_day_of_week(a_moment_on_a_thursday, target_day_name)).to be false
+      end
+    end
+
+    it "handles target day names case-insensitively" do
+      a_moment_on_last_friday = Time.local(2024, 5, 31, 10, 0, 0) # Last Friday of May 2024
+      expect(check_is_last_day_of_week(a_moment_on_last_friday, "friday")).to be true
+      expect(check_is_last_day_of_week(a_moment_on_last_friday, "FRIDAY")).to be true
+      expect(check_is_last_day_of_week(a_moment_on_last_friday, "FriDay")).to be true
+    end
+
+    it "returns false if the target_day_name is not a valid day name" do
+      a_moment_in_time = Time.local(2024, 5, 31, 10, 0, 0)
+      expect(check_is_last_day_of_week(a_moment_in_time, "InvalidDay")).to be false
+    end
+
+    it "returns false if the date passed is itself not the target_wday" do
+      a_thursday_moment = Time.local(2024, 5, 30, 10, 0, 0)
+      expect(check_is_last_day_of_week(a_thursday_moment, "Friday")).to be false
     end
   end
 end


### PR DESCRIPTION
This PR introduces custom scheduling rules to enhance the flexibility of task orchestration within the Manager class. Previously, scheduling was limited to interval, time, and day. Now, it's possible to define more advanced rules:
