### PR TITLE
feat: Add Elasticsearch Shared Storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem "simplecov-lcov", "~> 0.8.0"
 gem "vcr"
 gem "webmock"
 
+gem "elasticsearch", "~> 8.0"
 gem "httparty"
-
 gem "pg", "~> 1.5", ">= 1.5.4"
 
 group :test do

--- a/bas.gemspec
+++ b/bas.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Core dependencies
+  spec.add_dependency "elasticsearch", "~> 8.0"
   spec.add_dependency "httparty", "~> 0.22.0"
   spec.add_dependency "pg", "~> 1.5"
 

--- a/lib/bas/shared_storage/elasticsearch.rb
+++ b/lib/bas/shared_storage/elasticsearch.rb
@@ -43,7 +43,7 @@ module Bas
       def set_processed
         return if read_options[:avoid_process].eql?(true) || read_response.id.nil?
 
-        update_stage(read_response.id, "processed") unless @read_response.nil?
+        update_stage(read_response.id, "processed")
       end
 
       private
@@ -92,14 +92,16 @@ module Bas
       def write_body(data)
         if data[:success]
           return {
-            data: data[:success], tag: write_options[:tag], archived: false, inserted_at: Time.now.to_s,
+            data: data[:success], tag: write_options[:tag],
+            archived: false, inserted_at: Time.now.strftime("%Y-%m-%d %H:%M:%S %z"),
             stage: "unprocessed", status: "success", error_message: nil, version: Bas::VERSION
           }
         end
 
         {
-          data: nil, tag: write_options[:tag], archived: false, inserted_at: Time.now.to_s,
-          stage: "unprocessed", status: "failed", error_message: data[:error], version: Bas::VERSION
+          data: nil, tag: write_options[:tag], archived: false,
+          inserted_at: Time.now.strftime("%Y-%m-%d %H:%M:%S %z"), stage: "unprocessed",
+          status: "failed", error_message: data[:error], version: Bas::VERSION
         }
       end
       # rubocop:enable Metrics/MethodLength

--- a/lib/bas/shared_storage/elasticsearch.rb
+++ b/lib/bas/shared_storage/elasticsearch.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require_relative "base"
+require_relative "types/read"
+require_relative "../utils/elasticsearch/request"
+require_relative "../version"
+
+module Bas
+  module SharedStorage
+    ##
+    # The SharedStorage::Elasticsearch class serves as a shared storage implementation to read and write on
+    # a shared storage defined as a elasticsearch database
+    #
+    class Elasticsearch < Bas::SharedStorage::Base
+      def read
+        params = {
+          connection: read_options[:connection], index: read_options[:index],
+          query: read_body, method: :search
+        }
+
+        result = Utils::Elasticsearch::Request.execute(params)
+        @read_response = build_read_response(result)
+      end
+
+      def write(data)
+        params = {
+          connection: write_options[:connection],
+          index: write_options[:index],
+          body: write_body(data),
+          method: :index
+        }
+
+        create_mapping
+        @write_response = Utils::Elasticsearch::Request.execute(params).body
+      end
+
+      def set_in_process
+        return if read_options[:avoid_process].eql?(true) || read_response.id.nil?
+
+        update_stage(read_response.id, "in process")
+      end
+
+      def set_processed
+        return if read_options[:avoid_process].eql?(true) || read_response.id.nil?
+
+        update_stage(read_response.id, "processed") unless @read_response.nil?
+      end
+
+      private
+
+      # rubocop:disable Metrics/MethodLength
+      def create_mapping
+        params = {
+          connection: write_options[:connection],
+          index: write_options[:index],
+          body: {
+            mappings: {
+              properties: {
+                data: { type: "object" },
+                tag: { type: "text" },
+                archived: { type: "boolean" },
+                inserted_at: { type: "date", format: "yyyy-MM-dd HH:mm:ss Z" },
+                stage: { type: "text" },
+                status: { type: "text" },
+                error_message: { type: "object" },
+                version: { type: "text" }
+              }
+            }
+          },
+          method: :create_mapping
+        }
+
+        Utils::Elasticsearch::Request.execute(params)
+      end
+
+      def read_body
+        return read_options[:query] if read_options[:query].is_a?(Hash)
+
+        {
+          query: {
+            bool: {
+              must: [
+                { match: { status: "success" } }, { match: { tag: read_options[:tag] } },
+                { match: { archived: false } }, { match: { stage: "unprocessed" } }
+              ]
+            }
+          },
+          sort: [{ inserted_at: { order: "asc" } }]
+        }
+      end
+
+      def write_body(data)
+        if data[:success]
+          return {
+            data: data[:success], tag: write_options[:tag], archived: false, inserted_at: Time.now.to_s,
+            stage: "unprocessed", status: "success", error_message: nil, version: Bas::VERSION
+          }
+        end
+
+        {
+          data: nil, tag: write_options[:tag], archived: false, inserted_at: Time.now.to_s,
+          stage: "unprocessed", status: "failed", error_message: data[:error], version: Bas::VERSION
+        }
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def build_read_response(result)
+        first_hit = result["hits"]["hits"].empty? ? {} : result["hits"]["hits"].first
+        Bas::SharedStorage::Types::Read.new(
+          first_hit["_id"], first_hit["_source"]["data"].to_json, first_hit.dig("_source", "inserted_at")
+        )
+      end
+
+      def update_stage(id, stage)
+        params = {
+          connection: read_options[:connection],
+          index: read_options[:index],
+          id: id,
+          body: { doc: { stage: stage } },
+          method: :update
+        }
+
+        Utils::Elasticsearch::Request.execute(params)
+      end
+    end
+  end
+end

--- a/lib/bas/utils/elasticsearch/request.rb
+++ b/lib/bas/utils/elasticsearch/request.rb
@@ -52,7 +52,7 @@ module Utils
           when :search
             search(params, client)
           when :update
-            update_document(params, client)
+            update_documents(params, client)
           when :create_mapping
             create_mapping(params, client)
           end
@@ -74,8 +74,8 @@ module Utils
           client.index(index: params[:index], body: params[:body])
         end
 
-        def update_document(params, client)
-          client.update(index: params[:index], id: params[:id], body: params[:body])
+        def update_documents(params, client)
+          client.update_by_query(index: params[:index], body: params[:body], wait_for_completion: true, refresh: true)
         end
 
         def create_mapping(params, client)

--- a/lib/bas/utils/elasticsearch/request.rb
+++ b/lib/bas/utils/elasticsearch/request.rb
@@ -62,7 +62,7 @@ module Utils
             search_params[:q] = params[:query]
           end
 
-          client.search(search_params)
+          client.search(**search_params)
         end
 
         def index_document(params, client)

--- a/lib/bas/utils/elasticsearch/request.rb
+++ b/lib/bas/utils/elasticsearch/request.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "elasticsearch"
+
+module Utils
+  module Elasticsearch
+    ##
+    # This module is a ElasticsearchDB utility to make requests to a Elasticsearch database.
+    #
+    module Request
+      ALLOWED_METHODS = %i[search index].freeze
+
+      # Implements the request process logic to the ElasticsearchDB index.
+      #
+      # <br>
+      # <b>Params:</b>
+      # * <tt>connection</tt> Connection parameters to the database: `host`, `port`, `index`, `user`, `password`.
+      # * <b>query</b>:
+      #   * <tt>String</tt>: String with the Elasticsearch query to be executed.
+      #   * <tt>Array</tt>: Two element array, where the first element is the Elasticsearch query (string), and the
+      #                     second one an array of elements to be interpolared in the query when using "$1, $2, ...".
+      #
+      # <br>
+      # <b>returns</b> <tt>HTTParty::Response</tt>
+      #
+      class << self
+        def execute(params)
+          client = ::Elasticsearch::Client.new(
+            host: params[:connection][:host],
+            port: params[:connection][:port],
+            user: params[:connection][:user],
+            password: params[:connection][:password],
+            api_versioning: false,
+            transport_options: { ssl: { ca_file: params[:connection][:ca_file] } }
+          )
+
+          client.cluster.health
+          perform_request(params, client)
+        end
+
+        private
+
+        def perform_request(params, client)
+          case params[:method]
+          when :index
+            index_document(params, client)
+          when :search
+            search(params, client)
+          when :update
+            update_document(params, client)
+          when :create_mapping
+            create_mapping(params, client)
+          end
+        end
+
+        def search(params, client)
+          search_params = { index: params[:index] }
+          search_params[:size] = 1 # return only one document
+          if params[:query].is_a?(Hash)
+            search_params[:body] = params[:query]
+          else
+            search_params[:q] = params[:query]
+          end
+
+          client.search(search_params)
+        end
+
+        def index_document(params, client)
+          client.index(index: params[:index], body: params[:body])
+        end
+
+        def update_document(params, client)
+          client.update(index: params[:index], id: params[:id], body: params[:body])
+        end
+
+        def create_mapping(params, client)
+          return if client.indices.exists?(index: params[:index])
+
+          client.indices.create(index: params[:index], body: params[:body])
+        end
+      end
+    end
+  end
+end

--- a/spec/bas/shared_storage/elasticsearch_spec.rb
+++ b/spec/bas/shared_storage/elasticsearch_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "bas/shared_storage/elasticsearch"
+require "bas/shared_storage/types/read"
+
+RSpec.describe Bas::SharedStorage::Elasticsearch do
+  let(:connection) { { host: "localhost", port: 9200, user: "elastic", password: "password" } }
+  let(:read_options) { { connection:, index: "bas", tag: "my-tag" } }
+  let(:write_options) { { connection:, index: "bas", tag: "my-tag" } }
+  let(:read_response) { Bas::SharedStorage::Types::Read.new }
+  let(:process_success_response) { { success: "ok" } }
+  let(:process_error_response) { { error: "there was an error" } }
+  let(:es_response_body) do
+    {
+      "hits" => {
+        "hits" => [
+          {
+            "_id" => "1",
+            "_source" => {
+              "data" => { "success" => "ok" },
+              "inserted_at" => "2024-11-12T00:00:00"
+            }
+          }
+        ]
+      }
+    }
+  end
+  let(:es_response) { double("Elasticsearch::Response", body: es_response_body) }
+
+  before do
+    allow(Utils::Elasticsearch::Request).to receive(:execute).and_return(es_response)
+    allow(es_response).to receive(:[]).with("hits").and_return(es_response_body["hits"])
+  end
+
+  describe ".read" do
+    it "searches using default query" do
+      shared_storage = described_class.new(read_options:, write_options:)
+
+      expect(shared_storage.read).to be_a(Bas::SharedStorage::Types::Read)
+      expect(shared_storage.read_response).to be_a(Bas::SharedStorage::Types::Read)
+      expect(shared_storage.read_response.id).to eql("1")
+      expect(shared_storage.read_response.data).to eql({ "success" => "ok" })
+      expect(shared_storage.read_response.inserted_at).to eql("2024-11-12T00:00:00")
+    end
+
+    it "searches using a custom query" do
+      custom_query = { query: { match_all: {} } }
+      options = read_options.merge({ query: custom_query })
+      shared_storage = described_class.new(read_options: options, write_options:)
+
+      expect(Utils::Elasticsearch::Request).to receive(:execute).with(
+        hash_including(query: custom_query)
+      )
+
+      shared_storage.read
+    end
+  end
+
+  describe ".write" do
+    before { @shared_storage = described_class.new(read_options:, write_options:) }
+
+    it "saves a success result" do
+      expect(Utils::Elasticsearch::Request).to receive(:execute).twice
+      @shared_storage.write(process_success_response)
+      expect(@shared_storage.write_response).not_to be_nil
+    end
+
+    it "saves an error result" do
+      expect(Utils::Elasticsearch::Request).to receive(:execute).twice
+      @shared_storage.write(process_error_response)
+      expect(@shared_storage.write_response).not_to be_nil
+    end
+  end
+
+  describe ".set_in_process" do
+    it "ignores execution if avoid_process is true" do
+      options = read_options.merge({ avoid_process: true })
+      shared_storage = described_class.new(read_options: options, write_options:)
+      expect(shared_storage.set_in_process).to be_nil
+    end
+
+    it "updates the record stage to 'in process'" do
+      shared_storage = described_class.new(read_options:, write_options:)
+      shared_storage.read
+      expect(Utils::Elasticsearch::Request).to receive(:execute).with(
+        hash_including(method: :update, id: "1", body: { doc: { stage: "in process" } })
+      )
+      shared_storage.set_in_process
+    end
+  end
+
+  describe ".set_processed" do
+    it "ignores execution if avoid_process is true" do
+      options = read_options.merge({ avoid_process: true })
+      shared_storage = described_class.new(read_options: options, write_options:)
+      expect(shared_storage.set_processed).to be_nil
+    end
+
+    it "updates the record stage to 'processed'" do
+      shared_storage = described_class.new(read_options:, write_options:)
+      shared_storage.read
+      expect(Utils::Elasticsearch::Request).to receive(:execute).with(
+        hash_including(method: :update, id: "1", body: { doc: { stage: "processed" } })
+      )
+      shared_storage.set_processed
+    end
+  end
+end

--- a/spec/bas/utils/elasticsearch/request_spec.rb
+++ b/spec/bas/utils/elasticsearch/request_spec.rb
@@ -67,10 +67,10 @@ RSpec.describe Utils::Elasticsearch::Request do
           connection: connection_params,
           method: :update,
           index: "my-index",
-          id: "1",
-          body: { doc: { content: "Updated content." } }
+          body: { query: { match: { title: "test" } }, doc: { content: "Updated content." } }
         }
-        expect(es_client).to receive(:update).with(index: "my-index", id: "1", body: params[:body])
+        expect(es_client).to receive(:update_by_query)
+          .with(index: "my-index", body: params[:body], wait_for_completion: true, refresh: true)
         described_class.execute(params)
       end
     end

--- a/spec/bas/utils/elasticsearch/request_spec.rb
+++ b/spec/bas/utils/elasticsearch/request_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "bas/utils/elasticsearch/request"
+
+RSpec.describe Utils::Elasticsearch::Request do
+  let(:es_client) { instance_double(::Elasticsearch::Client) }
+  let(:cluster_client) { instance_double(::Elasticsearch::API::Cluster::Actions) }
+  let(:indices_client) { instance_double(::Elasticsearch::API::Indices::Actions) }
+
+  before do
+    allow(::Elasticsearch::Client).to receive(:new).and_return(es_client)
+    allow(es_client).to receive(:cluster).and_return(cluster_client)
+    allow(es_client).to receive(:indices).and_return(indices_client)
+    allow(cluster_client).to receive(:health)
+  end
+
+  describe ".execute" do
+    let(:connection_params) do
+      {
+        host: "localhost",
+        port: 9200,
+        user: "elastic",
+        password: "changeme",
+        ca_file: "/path/to/ca.crt"
+      }
+    end
+
+    context "when method is :search" do
+      let(:search_params) do
+        {
+          connection: connection_params,
+          method: :search,
+          index: "my-index"
+        }
+      end
+
+      it "performs a search with a string query" do
+        params = search_params.merge(query: "test query")
+        expect(es_client).to receive(:search).with(index: "my-index", size: 1, q: "test query")
+        described_class.execute(params)
+      end
+
+      it "performs a search with a hash query" do
+        query = { query: { match: { title: "test" } } }
+        params = search_params.merge(query: query)
+        expect(es_client).to receive(:search).with(index: "my-index", size: 1, body: query)
+        described_class.execute(params)
+      end
+    end
+
+    context "when method is :index" do
+      it "indexes a document" do
+        params = {
+          connection: connection_params,
+          method: :index,
+          index: "my-index",
+          body: { title: "Test Title", content: "Test content." }
+        }
+        expect(es_client).to receive(:index).with(index: "my-index", body: params[:body])
+        described_class.execute(params)
+      end
+    end
+
+    context "when method is :update" do
+      it "updates a document" do
+        params = {
+          connection: connection_params,
+          method: :update,
+          index: "my-index",
+          id: "1",
+          body: { doc: { content: "Updated content." } }
+        }
+        expect(es_client).to receive(:update).with(index: "my-index", id: "1", body: params[:body])
+        described_class.execute(params)
+      end
+    end
+
+    context "when method is :create_mapping" do
+      let(:mapping_params) do
+        {
+          connection: connection_params,
+          method: :create_mapping,
+          index: "my-index",
+          body: { mappings: { properties: { title: { type: "text" } } } }
+        }
+      end
+
+      it "creates an index with mapping if it does not exist" do
+        allow(indices_client).to receive(:exists?).with(index: "my-index").and_return(false)
+        expect(indices_client).to receive(:create).with(index: "my-index", body: mapping_params[:body])
+        described_class.execute(mapping_params)
+      end
+
+      it "does not create an index if it already exists" do
+        allow(indices_client).to receive(:exists?).with(index: "my-index").and_return(true)
+        expect(indices_client).not_to receive(:create)
+        described_class.execute(mapping_params)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces Elasticsearch as a new shared storage option, providing a scalable and flexible alternative to the existing Postgres implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using Elasticsearch as a shared storage backend, enabling reading, writing, and processing of data with Elasticsearch.
  * Introduced integration with the Elasticsearch gem.

* **Tests**
  * Added comprehensive tests for the new Elasticsearch shared storage functionality and its request handling utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->