### PR TITLE
Fix in Elasticsearch shared storage update_stage method

### DIFF
--- a/lib/bas/shared_storage/elasticsearch.rb
+++ b/lib/bas/shared_storage/elasticsearch.rb
@@ -125,7 +125,7 @@ module Bas
         response = Utils::Elasticsearch::Request.execute(params)
         return unless response["updated"].zero?
 
-        raise StandardError, "Document with id #{id} not found, so it was not updated"
+        raise StandardError, "Document #{id} not found, so it was not updated"
       end
     end
   end

--- a/lib/bas/shared_storage/elasticsearch.rb
+++ b/lib/bas/shared_storage/elasticsearch.rb
@@ -117,9 +117,11 @@ module Bas
         params = {
           connection: read_options[:connection],
           index: read_options[:index],
-          id: id,
-          body: { doc: { stage: stage } },
-          method: :update
+          method: :update,
+          body: {
+            query: { term: { _id: id } },
+            script: { source: "ctx._source.stage = params.new_value", params: { new_value: stage } }
+          }
         }
 
         Utils::Elasticsearch::Request.execute(params)

--- a/lib/bas/shared_storage/elasticsearch.rb
+++ b/lib/bas/shared_storage/elasticsearch.rb
@@ -115,16 +115,17 @@ module Bas
 
       def update_stage(id, stage)
         params = {
-          connection: read_options[:connection],
-          index: read_options[:index],
-          method: :update,
+          connection: read_options[:connection], index: read_options[:index], method: :update,
           body: {
-            query: { term: { _id: id } },
+            query: { ids: { values: [id] } },
             script: { source: "ctx._source.stage = params.new_value", params: { new_value: stage } }
           }
         }
 
-        Utils::Elasticsearch::Request.execute(params)
+        response = Utils::Elasticsearch::Request.execute(params)
+        return unless response["updated"].zero?
+
+        raise StandardError, "Document with id #{id} not found, so it was not updated"
       end
     end
   end

--- a/spec/bas/shared_storage/elasticsearch_spec.rb
+++ b/spec/bas/shared_storage/elasticsearch_spec.rb
@@ -100,9 +100,9 @@ RSpec.describe Bas::SharedStorage::Elasticsearch do
       shared_storage = described_class.new(read_options:, write_options:)
       shared_storage.read
       allow(Utils::Elasticsearch::Request).to receive(:execute).and_return({ "updated" => 0 })
-      expect {
+      expect do
         shared_storage.set_in_process
-      }.to raise_error(StandardError, /Document 1 not found/)
+      end.to raise_error(StandardError, /Document 1 not found/)
     end
   end
 
@@ -133,9 +133,9 @@ RSpec.describe Bas::SharedStorage::Elasticsearch do
       shared_storage = described_class.new(read_options:, write_options:)
       shared_storage.read
       allow(Utils::Elasticsearch::Request).to receive(:execute).and_return({ "updated" => 0 })
-      expect {
+      expect do
         shared_storage.set_processed
-      }.to raise_error(StandardError, /Document 1 not found/)
+      end.to raise_error(StandardError, /Document 1 not found/)
     end
   end
 end

--- a/spec/bas/shared_storage/elasticsearch_spec.rb
+++ b/spec/bas/shared_storage/elasticsearch_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Bas::SharedStorage::Elasticsearch do
     }
   end
   let(:es_response) { double("Elasticsearch::Response", body: es_response_body) }
+  let(:update_response) { { "updated" => 1 } }
 
   before do
     allow(Utils::Elasticsearch::Request).to receive(:execute).and_return(es_response)
@@ -82,10 +83,26 @@ RSpec.describe Bas::SharedStorage::Elasticsearch do
     it "updates the record stage to 'in process'" do
       shared_storage = described_class.new(read_options:, write_options:)
       shared_storage.read
+      allow(Utils::Elasticsearch::Request).to receive(:execute).and_return(update_response)
       expect(Utils::Elasticsearch::Request).to receive(:execute).with(
-        hash_including(method: :update, id: "1", body: { doc: { stage: "in process" } })
-      )
+        hash_including(
+          method: :update,
+          body: hash_including(
+            query: { ids: { values: ["1"] } },
+            script: hash_including(source: /ctx._source.stage/, params: { new_value: "in process" })
+          )
+        )
+      ).and_return(update_response)
       shared_storage.set_in_process
+    end
+
+    it "raises if no document was updated" do
+      shared_storage = described_class.new(read_options:, write_options:)
+      shared_storage.read
+      allow(Utils::Elasticsearch::Request).to receive(:execute).and_return({ "updated" => 0 })
+      expect {
+        shared_storage.set_in_process
+      }.to raise_error(StandardError, /Document 1 not found/)
     end
   end
 
@@ -99,10 +116,26 @@ RSpec.describe Bas::SharedStorage::Elasticsearch do
     it "updates the record stage to 'processed'" do
       shared_storage = described_class.new(read_options:, write_options:)
       shared_storage.read
+      allow(Utils::Elasticsearch::Request).to receive(:execute).and_return(update_response)
       expect(Utils::Elasticsearch::Request).to receive(:execute).with(
-        hash_including(method: :update, id: "1", body: { doc: { stage: "processed" } })
-      )
+        hash_including(
+          method: :update,
+          body: hash_including(
+            query: { ids: { values: ["1"] } },
+            script: hash_including(source: /ctx._source.stage/, params: { new_value: "processed" })
+          )
+        )
+      ).and_return(update_response)
       shared_storage.set_processed
+    end
+
+    it "raises if no document was updated" do
+      shared_storage = described_class.new(read_options:, write_options:)
+      shared_storage.read
+      allow(Utils::Elasticsearch::Request).to receive(:execute).and_return({ "updated" => 0 })
+      expect {
+        shared_storage.set_processed
+      }.to raise_error(StandardError, /Document 1 not found/)
     end
   end
 end


### PR DESCRIPTION
Refactor in `SharedStoage::Elasticsearch.update_stage` to reuse existing `Utils::Elasticsearch::Request.update` method passing a document id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of updating the stage field in Elasticsearch documents by applying updates via query and script, and raising an error if no matching document is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->