### PR TITLE
Return write_response after on bot execution

### DIFF
--- a/lib/bas/bot/base.rb
+++ b/lib/bas/bot/base.rb
@@ -34,6 +34,8 @@ module Bas
         @write_response = write
 
         close_connections if @process_options[:close_connections_after_process].eql?(true)
+
+        @write_response
       end
 
       protected


### PR DESCRIPTION
On a recent change on the PostgreSQL shared storage implementation, the `Bas::Bot::Base.execute` method calls `close_connections if @process_options[:close_connections_after_process].eql?(true)` as its last line, which replaces the previous behavior of returning the `write` call result: `@write_response = write`. This PR returns the previous behavior since current usages of the gem could rely on that response.

Also, [bas_use_cases](https://github.com/kommitters/bas_use_cases/actions/runs/16454350238/job/46507473841?pr=169) tests check a not-nil return on their tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response handling to ensure consistent return values after executing bot actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->